### PR TITLE
allow showing/hiding buffered geometries

### DIFF
--- a/module/pip/StatementPointInPolygon.js
+++ b/module/pip/StatementPointInPolygon.js
@@ -2,10 +2,19 @@ const _ = require('lodash')
 const SqliteStatement = require('../../sqlite/SqliteStatement')
 
 class StatementPointInPolygon extends SqliteStatement {
+  _selectStatement (query) {
+    let hasRole = _.get(query, 'role', '').length > 1
+
+    if (hasRole) { return this.statements.fetchWithRole }
+    return this.statements.fetch
+  }
   create (db, config) {
     try {
       let dbname = _.get(config, 'database', 'main')
-      this.statement = db.prepare(`
+      this.statements = {}
+
+      // fetch
+      this.statements.fetch = db.prepare(`
         SELECT place.*
         FROM ${dbname}.point_in_polygon AS pip
         LEFT JOIN place USING (source, id)
@@ -13,6 +22,20 @@ class StatementPointInPolygon extends SqliteStatement {
         AND INTERSECTS( pip.geom, MakePoint( @lon, @lat, 4326 ) )
         AND place.source IS NOT NULL
         LIMIT @limit
+      `)
+
+      // fetch filter by role
+      this.statements.fetchWithRole = db.prepare(`
+        SELECT source, id, class, type FROM (
+          SELECT source, id, class, type, role
+          FROM ${dbname}.point_in_polygon AS pip
+          LEFT JOIN place USING (source, id)
+          WHERE search_frame = MakePoint( @lon, @lat, 4326 )
+          AND INTERSECTS( pip.geom, MakePoint( @lon, @lat, 4326 ) )
+          AND place.source IS NOT NULL
+          LIMIT @limit
+        )
+        WHERE role = @role
       `)
     } catch (e) {
       this.error('PREPARE STATEMENT', e)

--- a/server/demo/assets/pip.js
+++ b/server/demo/assets/pip.js
@@ -90,7 +90,13 @@ $('document').ready(function () {
     let labels = getMapLayer(map, 'labels')
     labels.clearLayers()
 
-    api.pip({ lon: latlng.lng, lat: latlng.lat }, function (err, res) {
+    // handle role checkbox
+    let role = ''
+    if (!$('#show-buffered-geoms').is(':checked')) {
+      role = 'boundary'
+    }
+
+    api.pip({ lon: latlng.lng, lat: latlng.lat, role: role }, function (err, res) {
       if (err) { console.error(err) } else {
         updateMap(map, res)
         updateSidebar(map, res)
@@ -103,6 +109,11 @@ $('document').ready(function () {
   map.on('moveend', function (e) { pointInPolygon(map) })
   map.on('resize', function (e) { pointInPolygon(map) })
   $('#simplification').change(function () { pointInPolygon(map) })
+
+  // listen for updates to the role checkbox
+  $('#show-buffered-geoms').change(function () {
+    pointInPolygon(map)
+  })
 
   function onEachFeature (feature, layer) {
     if (feature.geometry.type.indexOf('Polygon') !== -1) {

--- a/server/demo/assets/style.css
+++ b/server/demo/assets/style.css
@@ -156,6 +156,15 @@ nav.breadcrumb {
   padding-bottom: 1px;
 }
 
+#sidebar-roles .roles-box {
+  position: relative;
+  padding: 10px 10px;
+}
+
+#sidebar-roles .roles-box input {
+  margin-right: 10px;
+}
+
 #simplification-info {
   position: absolute;
   top: 2px;
@@ -244,4 +253,12 @@ ul.typeahead__list ul.hierarchy li p {
 ul.typeahead__list ul.hierarchy li:not(:last-child)::after {
   content: ">";
   display: inline-block;
+}
+
+div.pip-role {
+  font-size: 0.7em;
+  margin: 5px;
+  display:block;
+  float:right;
+  color:#FFF;
 }

--- a/server/demo/views/pages/pip.hbs
+++ b/server/demo/views/pages/pip.hbs
@@ -18,6 +18,17 @@
       </div>
     </nav>
 
+    <!-- role sidebar -->
+    <nav id="sidebar-roles" class="panel">
+      <p class="panel-heading">Options</p>
+      <div class="roles-box">
+        <label class="checkbox">
+          <input id="show-buffered-geoms" type="checkbox">
+          Show Buffered Geometries
+        </label>
+      </div>
+    </nav>
+
     <!-- results sidebar -->
     <nav id="sidebar-results" class="panel">
       <p class="panel-heading">Hits</p>

--- a/server/routes/pip.js
+++ b/server/routes/pip.js
@@ -7,6 +7,7 @@ module.exports = function (req, res) {
   let query = {
     lon: parseFloat(util.flatten(req.query.lon)),
     lat: parseFloat(util.flatten(req.query.lat)),
+    role: util.flatten(req.query.role),
     limit: 1000
   }
 


### PR DESCRIPTION
The buffered geometries can be fairly numerous and clutter the PIP UI.
This PR adds a checkbox which enables/disables the retrieval and display of buffered geometries.