### PR TITLE
fix icons and logo + update dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,29 +32,29 @@
   "dependencies": {
     "@turf/buffer": "^5.1.5",
     "better-sqlite3": "^5.4.3",
-    "csv-parse": "^4.4.3",
+    "csv-parse": "^4.8.2",
     "express": "^4.17.1",
     "express-handlebars": "^3.1.0",
     "handlebars-helpers": "^0.10.0",
     "iso-639-3": "^1.2.0",
     "locale": "^0.1.0",
-    "lodash": "^4.17.11",
+    "lodash": "^4.17.15",
     "morgan": "^1.9.1",
     "pelias-logger": "^1.4.1",
     "split2": "^3.1.1",
     "through2": "^3.0.1",
     "turf-point": "^2.0.1",
-    "wkx": "^0.4.7",
-    "yargs": "^13.2.4"
+    "wkx": "^0.4.8",
+    "yargs": "^13.3.0"
   },
   "devDependencies": {
     "difflet": "^1.0.1",
-    "glob": "^7.1.4",
+    "glob": "^7.1.6",
     "precommit-hook": "^3.0.0",
-    "semver": "^6.1.2",
+    "semver": "^6.3.0",
     "standard": "^12.0.1",
     "tap-spec": "^5.0.0",
-    "tape": "^4.10.2"
+    "tape": "^4.11.0"
   },
   "standard": {
     "ignore": [

--- a/server/demo/views/layouts/default.hbs
+++ b/server/demo/views/layouts/default.hbs
@@ -5,8 +5,8 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no" />
   <meta name="apple-mobile-web-app-capable" content="yes">
   <meta name="mobile-web-app-capable" content="yes">
-  <link rel="icon" href="https://geocode.earth/favicon.ico" type="image/x-icon" />
-  
+  <link rel="icon" href="https://geocode.earth/favicon/favicon.ico" type="image/x-icon" />
+
   <script src="https://cdnjs.cloudflare.com/ajax/libs/modernizr/2.8.3/modernizr.js"></script>
   <script src="https://code.jquery.com/jquery-3.0.0.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/lodash.js/4.17.11/lodash.min.js"></script>
@@ -14,10 +14,10 @@
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/bulma/0.7.5/css/bulma.min.css" />
   <link rel="stylesheet"
     href="https://cdn.jsdelivr.net/npm/bulma-extensions@4.0.1/dist/css/bulma-extensions.min.css">
-  
+
   <link href="https://fonts.googleapis.com/css?family=Open+Sans:300,400,700" rel="stylesheet">
-  <script src="https://kit.fontawesome.com/9d98297a6e.js"></script>
-  
+  <script src="https://kit.fontawesome.com/66a62eca01.js" crossorigin="anonymous"></script>
+
   <script src="https://cdnjs.cloudflare.com/ajax/libs/leaflet/1.5.1/leaflet.js"></script>
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/leaflet/1.5.1/leaflet.css" />
   <script src="/explore/assets/vendor/leaflet-hash.js"></script>
@@ -34,7 +34,7 @@
   <link rel="stylesheet"
     href="https://cdnjs.cloudflare.com/ajax/libs/Leaflet.awesome-markers/2.0.2/leaflet.awesome-markers.css" />
   <script src="https://cdnjs.cloudflare.com/ajax/libs/Leaflet.awesome-markers/2.0.2/leaflet.awesome-markers.js"></script>
-  
+
   <link href="/explore/assets/tree.css" rel="stylesheet" />
   <link href="/explore/assets/style.css" rel="stylesheet" />
   <script src="/explore/assets/typeahead.js"></script>
@@ -52,9 +52,9 @@
   <nav class="navbar is-fixed-top" role="navigation" aria-label="main navigation">
     <div class="navbar-brand">
       <a class="navbar-item" href="https://geocode.earth" target="_blank">
-        <img src="https://geocode.earth/assets/ge-cda725f9fc7647fcb49d5fc9df2a3acb5fc4237c1db021d4e28f52f7cb924e7a.png" width="28" height="28">
+        <img src="https://geocode.earth/favicon/favicon-32x32.png" width="28" height="28">
       </a>
-  
+
       <a role="button" class="navbar-burger burger" aria-label="menu" aria-expanded="false"
         data-target="navbarBasicExample">
         <span aria-hidden="true"></span>
@@ -62,7 +62,7 @@
         <span aria-hidden="true"></span>
       </a>
     </div>
-  
+
     <div id="navbarBasicExample" class="navbar-menu">
       <div class="navbar-start">
         <a href="/explore/pip" class="navbar-item" data-append-hash>
@@ -72,7 +72,7 @@
           Ontology
         </a>
       </div>
-  
+
       <div class="navbar-end">
         <div class="navbar-item">
 


### PR DESCRIPTION
the `fontawesome` icons and Geocode Earth logo stopped working at some point, this PR restores them.
the `git commit` dep check was failing even after a fresh `rm -rf node_modules; npm i` but updating the packages resolved the issue.

resolves https://github.com/pelias/spatial/issues/34