### PR TITLE
spatialite: disable tinypoint

### DIFF
--- a/module/spatialite/InitSpatialOptions.js
+++ b/module/spatialite/InitSpatialOptions.js
@@ -10,15 +10,16 @@ class InitSpatialOptions extends Sqlite {
       this.error('SetDecimalPrecision', e)
     }
 
+    // disabled: it's convenient to be able to still use GeometryType() on 4.3.0a
     // Reduce the number of bytes required to represent a POINT geometry
     // note: this is a libspatialite-5.0.0 feature, databases generated with this setting
-    // cannot be read by older versions of spatialite.
+    // may not be read correctly by older versions of spatialite.
     // see: https://www.gaia-gis.it/fossil/libspatialite/wiki?name=BLOB-TinyPoint
-    try {
-      db.prepare(`SELECT EnableTinyPoint()`).get()
-    } catch (e) {
-      this.error('EnableTinyPoint', e)
-    }
+    // try {
+    //   db.prepare(`SELECT EnableTinyPoint()`).get()
+    // } catch (e) {
+    //   this.error('EnableTinyPoint', e)
+    // }
   }
 }
 


### PR DESCRIPTION
The `EnableTinyPoint()` setting in `spatialite 5` is a tradeoff
Prior to this PR I chose to save disk space at the cost of losing some backwards compatibility with `spatialite 4.3`
This PR reverts that decision, being able to use functions like `GeometryType` and knowing things will 'just work' on `4.3` is worth the extra bytes.