### PR TITLE
disable the contains and intersects spatial predicates which can cause slow load times

### DIFF
--- a/server/demo/views/pages/place.hbs
+++ b/server/demo/views/pages/place.hbs
@@ -12,8 +12,8 @@
         <div class="select">
           <select id="select-relationships">
             <option value="within" selected="selected">within</option>
-            <option value="contains">contains</option>
-            <option value="intersects">intersects</option>
+            <option disabled="disabled" value="contains">contains</option>
+            <option disabled="disabled" value="intersects">intersects</option>
           </select>
         </div>
         <span class="icon is-left">


### PR DESCRIPTION
disable the `contains` and `intersects` spatial predicates which can cause slow load times

these options can make the service unresponsive in a production environment when queries for things like "everything contained by the USA", so they're being disabled for now.

the 'within' option isn't so bad because it's only listing parents, not children, so it can stay.

<img width="315" alt="Screenshot 2020-04-15 at 15 24 59" src="https://user-images.githubusercontent.com/738069/79342475-7b78ed80-7f2d-11ea-8697-f51b9867602c.png">
