### PR TITLE
Add bash interpreter in dockerfile for more compatibility

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ RUN echo "@edge http://dl-cdn.alpinelinux.org/alpine/edge/main" >> /etc/apk/repo
 RUN apk update && \
   apk --no-cache --update upgrade musl && \
   apk add --upgrade --force-overwrite apk-tools@edge && \
-  apk add --update --force-overwrite gcc g++ musl-dev icu-dev icu-libs make sqlite python curl unzip jq nodejs npm && \
+  apk add --update --force-overwrite gcc g++ musl-dev icu-dev icu-libs make sqlite python curl unzip jq nodejs npm bash && \
   rm -rf /var/cache/apk/*
 
 RUN spatialite ':memory:' 'SELECT sqlite_version()'

--- a/bin/coverage
+++ b/bin/coverage
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 # run tests with pipefail to avoid false passes
 # see https://github.com/pelias/pelias/issues/744

--- a/bin/download_sqlite.sh
+++ b/bin/download_sqlite.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 # run tests with pipefail to avoid false passes
 # see https://github.com/pelias/pelias/issues/744

--- a/bin/env_check
+++ b/bin/env_check
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 # run tests with pipefail to avoid false passes
 # see https://github.com/pelias/pelias/issues/744

--- a/bin/test
+++ b/bin/test
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 # run tests with pipefail to avoid false passes
 # see https://github.com/pelias/pelias/issues/744


### PR DESCRIPTION
## Background

I'm using Debian, and sometime it's painful :cry: 
There are several `/bin/sh` implementations. Alpine is using [`ASH`](https://en.wikipedia.org/wiki/Almquist_shell) from [`BusyBox`](https://en.wikipedia.org/wiki/BusyBox) as shell interpreter.
On Debian, the `/bin/sh` implementation is [`DASH`](https://en.wikipedia.org/wiki/Almquist_shell#dash) and there is some differences between ASH and DASH... One of the difference is the `pipefail` option which does not exists in DASH :disappointed:...

## So?..

I suggest to add bash in the image (image size from 822MB to 823MB :man_shrugging:) and use `/bin/bash` as interpreter in all scripts.
This will avoid annoying errors on Debian like OS.