### PR TITLE
Set default view to Manhattan

### DIFF
--- a/server/demo/assets/map.js
+++ b/server/demo/assets/map.js
@@ -86,6 +86,7 @@ function setupMap (elementId, settings) {
   if (settings.hashControl === true) {
     var hash = new L.Hash(map)
     if (!location.hash) {
+      zoomToManhattan()
       // user declined popup
       map.once('locationerror', zoomToManhattan)
       map.locate({ setView: true, watch: false, maxZoom: 17 })


### PR DESCRIPTION
**Describe the bug**

When open the demo page, the demo page is just blank until it retrieve the location via browser Geolocation API.

**Expected behavior**

Load a default map view and then the user view.
