### PR TITLE
Uupdating `LD_LIBRARY_PATH` at runtime does not work

### DIFF
--- a/bin/spatial
+++ b/bin/spatial
@@ -1,9 +1,5 @@
 #!/bin/bash
 
-# run tests with pipefail to avoid false passes
-# see https://github.com/pelias/pelias/issues/744
-set -o pipefail
-
 RUNTIME="${RUNTIME:-/opt/spatial}"
 
 if [ -n "${PELIAS_SPATIAL_RUNTIME}" ] && [ -d "${PELIAS_SPATIAL_RUNTIME}" ]; then
@@ -16,4 +12,4 @@ if [ -n "${RUNTIME}" ] && [ -d "${RUNTIME}" ]; then
   export PROJ_LIB="${RUNTIME}/data:$PROJ_LIB" # set GEOS data path
 fi
 
-npx tap -J --no-cov --test-ignore='^test/'
+node bin/spatial.js $@

--- a/bin/start
+++ b/bin/start
@@ -1,9 +1,5 @@
 #!/bin/bash
 
-# run tests with pipefail to avoid false passes
-# see https://github.com/pelias/pelias/issues/744
-set -o pipefail
-
 RUNTIME="${RUNTIME:-/opt/spatial}"
 
 if [ -n "${PELIAS_SPATIAL_RUNTIME}" ] && [ -d "${PELIAS_SPATIAL_RUNTIME}" ]; then
@@ -16,4 +12,4 @@ if [ -n "${RUNTIME}" ] && [ -d "${RUNTIME}" ]; then
   export PROJ_LIB="${RUNTIME}/data:$PROJ_LIB" # set GEOS data path
 fi
 
-npx tap -J --no-cov --test-ignore='^test/'
+exec node server/http.js $@

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "homepage": "https://github.com/pelias/spatial",
   "license": "MIT",
   "main": "index.js",
-  "bin": "./bin/start",
+  "bin": "./bin/spatial",
   "scripts": {
     "postinstall": "npm run compile_sqlite",
     "compile_sqlite": "npm i better-sqlite3@6.0.1 --build-from-source --sqlite3=${RUNTIME:='/opt/spatial'}/src",
@@ -16,8 +16,8 @@
     "test": "./bin/test",
     "coverage": "./bin/coverage",
     "env_check": "./bin/env_check",
-    "start": "node server/http.js",
-    "server": "node server/http.js",
+    "start": "./bin/start",
+    "server": "./bin/start",
     "format_check": "./node_modules/standard/bin/cmd.js",
     "format_fix": "./node_modules/standard/bin/cmd.js --fix",
     "lint": "jshint ."

--- a/runtime/install/libxml2.sh
+++ b/runtime/install/libxml2.sh
@@ -21,7 +21,8 @@ cd libxml2
 # configure build
 ./configure \
   --prefix="${RUNTIME}" \
-  --enable-static=no
+  --enable-static=no \
+  --without-python
 
 # compile and install in runtime directory
 make -j8


### PR DESCRIPTION
Hi @missinglink, what you did with #58 and #59 is incredible ! Now everything is working fine on my laptop ! :smiling_face_with_three_hearts:  But I still need some changes :sweat_smile:.

----

I had an error when installing libxml2.
```
Making install in python
make[2]: Entering directory '/tmp/libxml2/python'
make  install-recursive
make[3]: Entering directory '/tmp/libxml2/python'
Making install in .
make[4]: Entering directory '/tmp/libxml2/python'
make[5]: Entering directory '/tmp/libxml2/python'
make[5]: Nothing to be done for 'install-exec-am'.
 /bin/mkdir -p '/opt/spatial/share/doc/libxml2-python-2.9.10'
 /usr/bin/install -c -m 644 TODO '/opt/spatial/share/doc/libxml2-python-2.9.10'
 /bin/mkdir -p '/usr/lib/python2.7/dist-packages'
 /usr/bin/install -c -m 644 drv_libxml2.py libxml2.py '/usr/lib/python2.7/dist-packages'
/usr/bin/install: cannot create regular file '/usr/lib/python2.7/dist-packages/drv_libxml2.py': Permission denied
/usr/bin/install: cannot create regular file '/usr/lib/python2.7/dist-packages/libxml2.py': Permission denied
```
The default python directory needs root privileges, but we are lucky we don't need python binding, so I added the option `--without-python`.

----

Then I ran a test `npm test` and I still got `SIGSEGV` even with the `RUNTIME` environment and the piece of code in `InitExtension.js`. So I added in `bin/test` the environment updates (with the correct `LD_LIBRARY_PATH` everything is working). I got the same issue with `node server/http.js`, so I added a new `bin/start`.

----

Then I tried `node bin/spatial.js serve` and I noticed that everything worked fine... I asked myself why ?
I found that when we use `bin/spatial.js`, it loads `InitExtension.js` (and update environment variables) and then spawn a new process with `LD_LIBRARY_PATH` correctly set. My guess is the node process should be spawned with the correct `LD_LIBRARY_PATH` environment.

That also means that `node bin/spatial.js import`, `node bin/spatial.js merge` and `node bin/spatial.js pip` do not work as-it.
I have two solutions and I would like your feedback @missinglink :

1. Move the environment code from `InitExtension.js` to `spatial.js` and spawn new processes for import, merge and pip (this implies instantiating `ImportService` from another file)
2. Encapsulate `bin/spatial.js` in a bash script which updates environment variables ?

----

I also added the environment `PELIAS_SPATIAL_RUNTIME` for `.bashrc` (less generic than `RUNTIME`)