### PR TITLE
update generic name & abbreviation to be compatible with wof-admin-lookup

### DIFF
--- a/import/source/whosonfirst/config/generic.js
+++ b/import/source/whosonfirst/config/generic.js
@@ -1,0 +1,69 @@
+const _ = require('lodash')
+
+/**
+ * This file provides some convenience functions for finding the 'generic name'
+ * and 'generic abbreviation' of a WOF document.
+ *
+ * This should probably be a lot easier than it is, and there seems to be some
+ * inconsistency within the Pelias codebase about which fields to prefer in
+ * certain cases.
+ *
+ * I've made a best-effort attempt to honour the field mappings which are (at time of writing)
+ * being used the pelias/wof-admin-lookup module.
+ * The idea is that this repo can be used as a drop-in replacement for wof-admin-lookup.
+ *
+ * Prior work:
+ * [N1] https://github.com/pelias/wof-admin-lookup/blob/e7ea48af6eb5b2b88886dd4b4f71a81e6e38696a/src/pip/components/getDefaultName.js
+ * [A1] https://github.com/pelias/wof-admin-lookup/blob/d9abfe32ed40184bd657df463e2faeb6ff2f7326/src/pip/components/extractFields.js#L44-L51
+ * [A2] https://github.com/pelias/whosonfirst/blob/fee549816a8a29fc5c3daccc66129677f8d552d6/src/components/extractFields.js#L154
+ */
+
+// convenience function to find a generic name for the place
+function getName (properties) {
+  const placeType = _.get(properties, 'wof:placetype')
+  const ISOcountry = _.get(properties, 'iso:country')
+  const quattroAlt = _.get(properties, 'qs:a2_alt')
+  const label = _.get(properties, 'wof:label')
+  const name = _.get(properties, 'wof:name')
+
+  // this US-county specific logic was ported from [A1]
+  if (ISOcountry === 'US' && placeType === 'county' && quattroAlt) {
+    return quattroAlt.trim()
+  }
+
+  // use label
+  if (label) { return label.trim() }
+
+  // use name
+  if (name) { return name.trim() }
+}
+
+// convenience function to find a generic abbreviation for the place
+function getAbbreviation (properties) {
+  const placeType = _.get(properties, 'wof:placetype')
+  const countryCode = _.get(properties, 'wof:country_alpha3')
+  const shortCode = _.get(properties, 'wof:shortcode')
+  const abbreviation = _.get(properties, 'wof:abbreviation')
+  const country = _.get(properties, 'wof:country')
+
+  // use the 3 letter country code for 'country' placetypes
+  if (placeType === 'country' && countryCode) {
+    return countryCode.trim()
+  }
+
+  // use shortcode
+  if (shortCode) { return shortCode.trim() }
+
+  // use abbreviation
+  if (abbreviation) { return abbreviation.trim() }
+
+  // support the deprecated 'wof:country' field
+  if (placeType === 'dependency' && country) {
+    return country.trim()
+  }
+}
+
+module.exports = {
+  name: getName,
+  abbreviation: getAbbreviation
+}

--- a/import/source/whosonfirst/map/names.js
+++ b/import/source/whosonfirst/map/names.js
@@ -1,12 +1,12 @@
-const _ = require('lodash')
 const Name = require('../../../../model/Name')
 const language = require('../config/language.json')
+const generic = require('../config/generic')
 
 // info about 'abrv': https://github.com/whosonfirst-data/whosonfirst-data/issues/1319
 function mapper (place, properties) {
-  // generic name properties
-  place.addName(new Name('und', 'default', false, _.get(properties, 'wof:name', '').trim()))
-  place.addName(new Name('und', 'default', true, _.get(properties, 'wof:abbreviation', '').trim()))
+  // generic name/abbreviation
+  place.addName(new Name('und', 'default', false, generic.name(properties)))
+  place.addName(new Name('und', 'default', true, generic.abbreviation(properties)))
 
   for (let attr in properties) {
     if (!attr.startsWith('name:') && !attr.startsWith('abrv:')) { continue }

--- a/import/source/whosonfirst/map/names.test.js
+++ b/import/source/whosonfirst/map/names.test.js
@@ -10,9 +10,15 @@ tap.test('mapper: properties empty', (t) => {
   t.equals(p.name.length, 0)
   t.end()
 })
-tap.test('mapper: wof:name', (t) => {
+
+// generic name
+tap.test('mapper: wof:name - prefer wof:label over wof:name', (t) => {
   let p = new Place()
-  map(p, { 'wof:name': 'example1' })
+  map(p, {
+    'wof:label': 'example1',
+    'wof:name': 'example2',
+    'qs:a2_alt': 'example3'
+  })
 
   t.equals(p.name.length, 1)
   t.equals(p.name[0].lang, 'und')
@@ -21,9 +27,79 @@ tap.test('mapper: wof:name', (t) => {
   t.equals(p.name[0].name, 'example1')
   t.end()
 })
-tap.test('mapper: wof:abbreviation', (t) => {
+tap.test('mapper: wof:name - use wof:name when wof:label unset', (t) => {
   let p = new Place()
-  map(p, { 'wof:abbreviation': 'example1' })
+  map(p, {
+    'wof:name': 'example2',
+    'qs:a2_alt': 'example3'
+  })
+
+  t.equals(p.name.length, 1)
+  t.equals(p.name[0].lang, 'und')
+  t.equals(p.name[0].tag, 'default')
+  t.equals(p.name[0].abbr, false)
+  t.equals(p.name[0].name, 'example2')
+  t.end()
+})
+tap.test('mapper: wof:name - use qs:a2_alt for USA counties', (t) => {
+  let p = new Place()
+  map(p, {
+    'iso:country': 'US',
+    'wof:placetype': 'county',
+    'wof:label': 'example1',
+    'wof:name': 'example2',
+    'qs:a2_alt': 'example3'
+  })
+
+  t.equals(p.name.length, 1)
+  t.equals(p.name[0].lang, 'und')
+  t.equals(p.name[0].tag, 'default')
+  t.equals(p.name[0].abbr, false)
+  t.equals(p.name[0].name, 'example3')
+  t.end()
+})
+
+// generic abbreviation
+tap.test('mapper: wof:abbreviation - prefer wof:shortcode over wof:abbreviation', (t) => {
+  let p = new Place()
+  map(p, {
+    'wof:country_alpha3': 'example1',
+    'wof:shortcode': 'example2',
+    'wof:abbreviation': 'example3',
+    'wof:country': 'example4'
+  })
+
+  t.equals(p.name.length, 1)
+  t.equals(p.name[0].lang, 'und')
+  t.equals(p.name[0].tag, 'default')
+  t.equals(p.name[0].abbr, true)
+  t.equals(p.name[0].name, 'example2')
+  t.end()
+})
+tap.test('mapper: wof:abbreviation - use wof:abbreviation when wof:shortcode unset', (t) => {
+  let p = new Place()
+  map(p, {
+    'wof:country_alpha3': 'example1',
+    'wof:abbreviation': 'example3',
+    'wof:country': 'example4'
+  })
+
+  t.equals(p.name.length, 1)
+  t.equals(p.name[0].lang, 'und')
+  t.equals(p.name[0].tag, 'default')
+  t.equals(p.name[0].abbr, true)
+  t.equals(p.name[0].name, 'example3')
+  t.end()
+})
+tap.test('mapper: wof:abbreviation - prefer country_alpha3 for country placetype', (t) => {
+  let p = new Place()
+  map(p, {
+    'wof:placetype': 'country',
+    'wof:country_alpha3': 'example1',
+    'wof:shortcode': 'example2',
+    'wof:abbreviation': 'example3',
+    'wof:country': 'example4'
+  })
 
   t.equals(p.name.length, 1)
   t.equals(p.name[0].lang, 'und')
@@ -32,6 +108,21 @@ tap.test('mapper: wof:abbreviation', (t) => {
   t.equals(p.name[0].name, 'example1')
   t.end()
 })
+tap.test('mapper: wof:abbreviation - use wof:country as last resort for dependency placetype', (t) => {
+  let p = new Place()
+  map(p, {
+    'wof:placetype': 'dependency',
+    'wof:country': 'example4'
+  })
+
+  t.equals(p.name.length, 1)
+  t.equals(p.name[0].lang, 'und')
+  t.equals(p.name[0].tag, 'default')
+  t.equals(p.name[0].abbr, true)
+  t.equals(p.name[0].name, 'example4')
+  t.end()
+})
+
 tap.test('mapper: name', (t) => {
   let p = new Place()
   map(p, { 'name:eng_x_preferred': [ 'example1', 'example2' ] })


### PR DESCRIPTION
I was comparing the output of PIP results for `wof-admin-lookup` vs `spatial` and noticed that the abbreviations were different.

<img width="551" alt="Screenshot 2020-07-06 at 15 09 32" src="https://user-images.githubusercontent.com/738069/86597021-73b06e80-bf9b-11ea-8e98-e9c2c67c7c38.png">
<img width="548" alt="Screenshot 2020-07-06 at 15 09 39" src="https://user-images.githubusercontent.com/738069/86597028-757a3200-bf9b-11ea-8464-cca83bb81547.png">


So I've ported the old logic from `wof-admin-lookup` in order to select the same fields.

It's actually a bit of a mess and took me a while to dig around the repos trying to figure out what's correct, there are some bits which are unusual, like using the `qs:a2_alt` field 🤷 

In the end I chose to honour what we were doing in `wof-admin-lookup` and we can worry about whether or not that is 'correct' later 😆 