### PR TITLE
experimenting with UK ONSPD format

### DIFF
--- a/import/source/onspd.js
+++ b/import/source/onspd.js
@@ -1,0 +1,7 @@
+const file = require('../../import/file')
+
+module.exports = {
+  ingress: file,
+  format: 'csv',
+  mapper: require('./onspd/map/place')
+}

--- a/import/source/onspd/map/geometries.js
+++ b/import/source/onspd/map/geometries.js
@@ -1,0 +1,56 @@
+const _ = require('lodash')
+const format = require('../../../format')
+const Geometry = require('../../../../model/Geometry')
+const rad = 0.001 // select a buffer radius
+
+const turf = {
+  point: require('turf-point'),
+  buffer: require('@turf/buffer')
+}
+
+function mapper (place, doc) {
+  // convert CSV rows to geojson point
+  const geometry = {
+    type: 'Point',
+    coordinates: [
+      parseFloat(_.get(doc, 'long')),
+      parseFloat(_.get(doc, 'lat'))
+    ]
+  }
+
+  // there are some errors in the data such as:
+  // { pcd: 'AB113AG', lat: '99.999999', long: '0.000000' }
+  if (
+    (geometry.coordinates[0] === 0 && geometry.coordinates[1] === 0) ||
+    !_.inRange(geometry.coordinates[0], -180, 180) ||
+    !_.inRange(geometry.coordinates[1], -90, 90)
+  ) {
+    console.error(`invalid coordinates for ${place.identity.id}`, geometry.coordinates)
+    return
+  }
+
+  // add a explicit centroid geometry so that one
+  // does not need to be calculated.
+  place.addGeometry(new Geometry(
+    format.from('geometry', 'geojson', geometry),
+    'centroid'
+  ))
+
+  try {
+    // buffer POINT to a create a POLYGON
+    var point = turf.point(geometry.coordinates)
+    var buffered = turf.buffer(point, rad, { units: 'degrees', steps: 8 })
+
+    place.addGeometry(new Geometry(
+      format.from('geometry', 'geojson', buffered.geometry),
+      'buffer'
+    ))
+  } catch (e) {
+    // there are some errors in the data such as:
+    // { pcd: 'AB113AG', lat: '99.999999', long: '0.000000' }
+    console.error(`Geometry buffering failed for ${place.identity.id}`, geometry.coordinates)
+    console.error(e.message)
+  }
+}
+
+module.exports = mapper

--- a/import/source/onspd/map/place.js
+++ b/import/source/onspd/map/place.js
@@ -1,0 +1,34 @@
+const _ = require('lodash')
+const Identity = require('../../../../model/Identity')
+const Ontology = require('../../../../model/Ontology')
+const Place = require('../../../../model/Place')
+const Property = require('../../../../model/Property')
+const Name = require('../../../../model/Name')
+
+const map = {
+  geometries: require('./geometries')
+}
+
+function mapper (doc) {
+  // instantiate a new place
+  const place = new Place(
+    new Identity('onspd', _.get(doc, 'pcd', 'unknown').replace(/\s/g, '')),
+    new Ontology('admin', _.get(doc, 'place', 'postalcode'))
+  )
+
+  // map all columns to properties
+  for (let key in doc) {
+    place.addProperty(new Property(`onspd:${key}`, doc[key]))
+  }
+
+  // name property
+  place.addName(new Name('und', 'default', false, _.get(doc, 'pcd2')))
+  place.addName(new Name('und', 'default', true, _.get(doc, 'pcd')))
+
+  // map geometries
+  map.geometries(place, doc)
+
+  return place
+}
+
+module.exports = mapper


### PR DESCRIPTION
This PR adds support for the ONS Postcode Directory (ONSPD) for the United Kingdom
https://geoportal.statistics.gov.uk/datasets/ons-postcode-directory-may-2020

I was interested to see what the coverage was like and found out:
- It's centroids only
- 2,643,729 rows in the file, each is a valid UK postcode
- Some of the rows have bunk coordinates

To use this importer, download the `ONSPD_MAY_2020_UK.csv` file from the link above and import it as such:
```bash
# import the whole file
cat ONSPD_MAY_2020_UK.csv | node bin/spatial.js import onspd

# import just the CSV header and some postcode starting with.. (for quick dev work)
cat ONSPD_MAY_2020_UK.csv | grep  -e 'ur01ind,oac01' -e '^"E8' | node bin/spatial.js import onspd
```

I had a quick play around with buffering the points to polygons and settled on a `0.001` radius, but this is obviously not an. exact science.

<img width="845" alt="Screenshot 2020-07-16 at 11 12 41" src="https://user-images.githubusercontent.com/738069/87653823-61ca8a80-c756-11ea-901c-3aa1c5ada1d8.png">

cc/ @vicchi

