### PR TITLE
add readme section on load-testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,3 +152,38 @@ node bin/spatial.js server --db=geo.local.db
 # run point-in-polygon query
 node bin/spatial.js --db=geo.local.db pip 174.766843 -41.288788
 ```
+
+# Performance Testing
+
+For performance critial HTTP APIs we have two methods of load-testing:
+
+## K6
+
+For some basic tests you can use [k6](https://github.com/loadimpact/k6) to write perf tests in javascript:
+
+```javascript
+import http from 'k6/http'
+const baseurl = 'http://localhost:3000/query/pip/_view/pelias'
+
+function randomFloat(from, to, fixed) {
+  return (Math.random() * (to - from) + from).toFixed(fixed) * 1
+}
+
+export default function() {
+  let lon = randomFloat(-180, +180, 8)
+  let lat = randomFloat(-90, +90, 8)
+  http.get(`${baseurl}/${lon}/${lat}`)
+}
+```
+
+```bash
+k6 run --vus 20 --iterations 100000 test.js
+```
+
+## Gatling
+
+Jawg provide a [suite of stress-testing tools](https://github.com/jawg/pelias-server-stress) for benchmarking various Pelias services.
+
+These tools are powered by [Gatling](https://gatling.io/) which can produce impressive visual charts and provide more information about where the bottlenecks are occurring (ie. disk congestion).
+
+see https://github.com/pelias/spatial/issues/7 for examples


### PR DESCRIPTION
moved some of the load-testing knowledge from https://github.com/pelias/spatial/issues/7 to the readme.

@Joxit I'm not familiar with https://github.com/jawg/pelias-server-stress, did I do an OK job of describing it?