### PR TITLE
auto rebuild runtime baseimages upon push to runtime branch

### DIFF
--- a/.github/workflows/runtime_alpine_3_10.yml
+++ b/.github/workflows/runtime_alpine_3_10.yml
@@ -1,0 +1,20 @@
+name: 'build & push: runtime_alpine_3_10'
+on:
+  push:
+    branches:
+      - runtime
+jobs:
+  push_to_registry:
+    name: 'build & push: runtime_alpine_3_10'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v2
+      - name: runtime_alpine_3_10
+        uses: docker/build-push-action@v1
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+          repository: pelias/spatial
+          dockerfile: runtime/runtime.alpine.3.10.Dockerfile
+          tags: runtime_alpine_3_10

--- a/.github/workflows/runtime_debian_buster.yml
+++ b/.github/workflows/runtime_debian_buster.yml
@@ -1,0 +1,20 @@
+name: 'build & push: runtime_debian_buster'
+on:
+  push:
+    branches:
+      - runtime
+jobs:
+  push_to_registry:
+    name: 'build & push: runtime_debian_buster'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v2
+      - name: runtime_debian_buster
+        uses: docker/build-push-action@v1
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+          repository: pelias/spatial
+          dockerfile: runtime/runtime.debian.buster.Dockerfile
+          tags: runtime_debian_buster

--- a/.github/workflows/runtime_ubuntu_bionic.yml
+++ b/.github/workflows/runtime_ubuntu_bionic.yml
@@ -1,0 +1,20 @@
+name: 'build & push: runtime_ubuntu_bionic'
+on:
+  push:
+    branches:
+      - runtime
+jobs:
+  push_to_registry:
+    name: 'build & push: runtime_ubuntu_bionic'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v2
+      - name: runtime_ubuntu_bionic
+        uses: docker/build-push-action@v1
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+          repository: pelias/spatial
+          dockerfile: runtime/runtime.ubuntu.bionic.Dockerfile
+          tags: runtime_ubuntu_bionic

--- a/.github/workflows/runtime_ubuntu_focal.yml
+++ b/.github/workflows/runtime_ubuntu_focal.yml
@@ -1,0 +1,20 @@
+name: 'build & push: runtime_ubuntu_focal'
+on:
+  push:
+    branches:
+      - runtime
+jobs:
+  push_to_registry:
+    name: 'build & push: runtime_ubuntu_focal'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v2
+      - name: runtime_ubuntu_focal
+        uses: docker/build-push-action@v1
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+          repository: pelias/spatial
+          dockerfile: runtime/runtime.ubuntu.focal.Dockerfile
+          tags: runtime_ubuntu_focal

--- a/runtime/README.md
+++ b/runtime/README.md
@@ -55,6 +55,8 @@ npm run env_check
 
 ## Docker Runtime Environments
 
+> Push to the `runtime` branch to have Github Actions rebuild all runtime images & push them to Docker Hub
+
 ### Ubuntu Bionic (18.04) `pelias/spatial:runtime_ubuntu_bionic`
 
 ```bash

--- a/runtime/runtime.alpine.3.10.Dockerfile
+++ b/runtime/runtime.alpine.3.10.Dockerfile
@@ -5,8 +5,8 @@ RUN echo "@edge http://dl-cdn.alpinelinux.org/alpine/edge/main" >> /etc/apk/repo
 RUN apk update && \
   apk --no-cache --update upgrade musl && \
   apk add --upgrade --force-overwrite apk-tools@edge && \
-  apk add --update --force-overwrite autoconf automake gcc g++ libtool make musl-dev && \
-  apk add --update --force-overwrite curl-dev && \
+  apk add --update --force-overwrite autoconf automake gcc g++ libtool make musl-dev@edge && \
+  apk add --update --force-overwrite curl-dev minizip-dev && \
   apk add --update --force-overwrite bash curl file unzip && \
   apk add --update --force-overwrite fossil git && \
   rm -rf /var/cache/apk/*

--- a/runtime/runtime.debian.buster.Dockerfile
+++ b/runtime/runtime.debian.buster.Dockerfile
@@ -4,7 +4,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 # apt dependencies
 RUN apt-get update -y && \
   apt-get install -y build-essential autoconf libtool pkg-config && \
-  apt-get install -y libcurl4-gnutls-dev && \
+  apt-get install -y libcurl4-gnutls-dev libminizip-dev && \
   apt-get install -y curl unzip && \
   apt-get install -y fossil git-core && \
   rm -rf /var/lib/apt/lists/*

--- a/runtime/runtime.ubuntu.bionic.Dockerfile
+++ b/runtime/runtime.ubuntu.bionic.Dockerfile
@@ -4,7 +4,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 # apt dependencies
 RUN apt-get update -y && \
   apt-get install -y build-essential autoconf libtool pkg-config && \
-  apt-get install -y libcurl4-gnutls-dev && \
+  apt-get install -y libcurl4-gnutls-dev libminizip-dev && \
   apt-get install -y curl unzip && \
   apt-get install -y fossil git-core && \
   rm -rf /var/lib/apt/lists/*

--- a/runtime/runtime.ubuntu.focal.Dockerfile
+++ b/runtime/runtime.ubuntu.focal.Dockerfile
@@ -4,7 +4,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 # apt dependencies
 RUN apt-get update -y && \
   apt-get install -y build-essential autoconf libtool pkg-config && \
-  apt-get install -y libcurl4-gnutls-dev && \
+  apt-get install -y libcurl4-gnutls-dev libminizip-dev && \
   apt-get install -y curl unzip && \
   apt-get install -y fossil git-core && \
   rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
This PR enabled Github Actions to rebuild the runtime baseimages using Github actions

Since rebuilding the runtime images is an occasional task it's only configured to run on pushes to the `runtime` branch (for now).