### PR TITLE
upgrade to spatialite 5.0.0-RC1

### DIFF
--- a/runtime/install/zlib.sh
+++ b/runtime/install/zlib.sh
@@ -18,10 +18,21 @@ curl -L 'http://downloads.sourceforge.net/project/libpng/zlib/1.2.11/zlib-1.2.11
 # working directory
 cd zlib
 
-# configure build
+# configure zlib build
 ./configure --prefix="${RUNTIME}"
 
-# compile and install in runtime directory
+# compile and install zlib in runtime directory
+make -j8
+make install
+
+# install minizip
+cd contrib/minizip
+
+# configure minizip build
+autoreconf -i
+./configure --prefix="${RUNTIME}"
+
+# compile and install minizip in runtime directory
 make -j8
 make install
 

--- a/runtime/runtime.alpine.3.10.Dockerfile
+++ b/runtime/runtime.alpine.3.10.Dockerfile
@@ -6,7 +6,7 @@ RUN apk update && \
   apk --no-cache --update upgrade musl && \
   apk add --upgrade --force-overwrite apk-tools@edge && \
   apk add --update --force-overwrite autoconf automake gcc g++ libtool make musl-dev@edge && \
-  apk add --update --force-overwrite curl-dev minizip-dev && \
+  apk add --update --force-overwrite curl-dev && \
   apk add --update --force-overwrite bash curl file unzip && \
   apk add --update --force-overwrite fossil git && \
   rm -rf /var/cache/apk/*

--- a/runtime/runtime.debian.buster.Dockerfile
+++ b/runtime/runtime.debian.buster.Dockerfile
@@ -4,7 +4,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 # apt dependencies
 RUN apt-get update -y && \
   apt-get install -y build-essential autoconf libtool pkg-config && \
-  apt-get install -y libcurl4-gnutls-dev libminizip-dev && \
+  apt-get install -y libcurl4-gnutls-dev && \
   apt-get install -y curl unzip && \
   apt-get install -y fossil git-core && \
   rm -rf /var/lib/apt/lists/*

--- a/runtime/runtime.ubuntu.bionic.Dockerfile
+++ b/runtime/runtime.ubuntu.bionic.Dockerfile
@@ -3,8 +3,8 @@ ENV DEBIAN_FRONTEND=noninteractive
 
 # apt dependencies
 RUN apt-get update -y && \
-  apt-get install -y build-essential autoconf libtool pkg-config && \
-  apt-get install -y libcurl4-gnutls-dev libminizip-dev && \
+  apt-get install -y build-essential autoconf libtool pkg-config cmake && \
+  apt-get install -y libcurl4-gnutls-dev && \
   apt-get install -y curl unzip && \
   apt-get install -y fossil git-core && \
   rm -rf /var/lib/apt/lists/*

--- a/runtime/runtime.ubuntu.focal.Dockerfile
+++ b/runtime/runtime.ubuntu.focal.Dockerfile
@@ -4,7 +4,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 # apt dependencies
 RUN apt-get update -y && \
   apt-get install -y build-essential autoconf libtool pkg-config && \
-  apt-get install -y libcurl4-gnutls-dev libminizip-dev && \
+  apt-get install -y libcurl4-gnutls-dev && \
   apt-get install -y curl unzip && \
   apt-get install -y fossil git-core && \
   rm -rf /var/lib/apt/lists/*

--- a/test/environment.js
+++ b/test/environment.js
@@ -37,7 +37,7 @@ tap.test('dependencies', (t) => {
   t.equals(res['sqlite_version()'], '3.31.1', `sqlite_version: ${res['sqlite_version()']}`)
 
   res = db.prepare(`SELECT spatialite_version()`).get()
-  t.equal(res['spatialite_version()'], '5.0.0-beta1', 'spatialite 5 beta1 required')
+  t.equal(res['spatialite_version()'], '5.0.0-RC1', 'spatialite 5 RC1 required')
 
   res = db.prepare(`SELECT spatialite_target_cpu()`).get()
   t.true(res['spatialite_target_cpu()'].startsWith('x86_64'), `spatialite_target_cpu: ${res['spatialite_target_cpu()']}`)


### PR DESCRIPTION
- compile minizip into runtime dir to avoid requiring it as a dependency
- upgrade to spatialite 5.0.0-RC1 🎉 
