### PR TITLE
Should return only placetypes supported by old pip-service

### DIFF
--- a/server/routes/pip_pelias.js
+++ b/server/routes/pip_pelias.js
@@ -1,4 +1,20 @@
 const verbose = require('./pip_verbose')
+const layerCompatibility = new Set([
+  'neighbourhood',
+  'borough',
+  'locality',
+  'localadmin',
+  'county',
+  'macrocounty',
+  'macroregion',
+  'region',
+  'dependency',
+  'country',
+  'empire',
+  'continent',
+  'marinearea',
+  'ocean'
+])
 
 // a custom 'view' which emulates the legacy pelias PIP format (with some additions!)
 // see: https://github.com/pelias/wof-admin-lookup
@@ -17,15 +33,19 @@ module.exports = function (req, res) {
 // rewite the verbose view to match the expected format
 function remap (resp) {
   for (let placetype in resp) {
-    resp[placetype] = resp[placetype].map(row => {
-      return {
-        id: parseInt(row.id, 10),
-        name: row.name,
-        abbr: row.abbr,
-        centroid: row.centroid,
-        bounding_box: row.bounding_box
-      }
-    })
+    if (layerCompatibility.has(placetype)) {
+      resp[placetype] = resp[placetype].map(row => {
+        return {
+          id: parseInt(row.id, 10),
+          name: row.name,
+          abbr: row.abbr,
+          centroid: row.centroid,
+          bounding_box: row.bounding_box
+        }
+      })
+    } else {
+      delete resp[placetype]
+    }
   }
   return resp
 }


### PR DESCRIPTION
Hi there :smile: 

I'm planning to use spatial in production, so I'm doing some full import and tests.

I found something during my full import, this error message :
```
error: [dbclient-geonames] [400] type=strict_dynamic_mapping_exception, reason=mapping set to strict, dynamic introduction of [macrohood] within [parent] is not allowed
```

The schema has a strict mapping and `macrohood` is not a part of it (see [document.js](https://github.com/pelias/schema/blob/384e3843082409781b6d8de0653e49dfc24e7cc8/mappings/document.js#L66-L160)).

My first idea is to restrict the output of the backward-compatible endpoint to the list of known placetypes from [wof-admin-lookup](https://github.com/pelias/wof-admin-lookup/blob/b508c33d005955b8dc6cdb88295899342b208908/src/pip/index.js#L23-L38)

