### PR TITLE
Add support for non wof datasources

### DIFF
--- a/server/routes/pip_pelias.js
+++ b/server/routes/pip_pelias.js
@@ -1,4 +1,5 @@
 const verbose = require('./pip_verbose')
+const _ = require('lodash')
 const layerCompatibility = new Set([
   'neighbourhood',
   'borough',
@@ -19,12 +20,13 @@ const layerCompatibility = new Set([
 // a custom 'view' which emulates the legacy pelias PIP format (with some additions!)
 // see: https://github.com/pelias/wof-admin-lookup
 module.exports = function (req, res) {
+  const wofOnlyHeader = _.get(req, 'headers.x-wof-only', 'true')
   // inputs
   req.query = {
     lon: req.params.lon,
     lat: req.params.lat,
     aliaslimit: 0,
-    wofonly: 1
+    wofonly: wofOnlyHeader === 'false' || wofOnlyHeader === '0' ? 0 : 1
   }
 
   verbose.bind({ remap: remap })(req, res)
@@ -34,15 +36,18 @@ module.exports = function (req, res) {
 function remap (resp) {
   for (let placetype in resp) {
     if (layerCompatibility.has(placetype)) {
-      resp[placetype] = resp[placetype].map(row => {
-        return {
-          id: parseInt(row.id, 10),
-          name: row.name,
-          abbr: row.abbr,
-          centroid: row.centroid,
-          bounding_box: row.bounding_box
-        }
-      })
+      resp[placetype] = resp[placetype]
+        .filter(row => row.name && row.id)
+        .map(row => {
+          return {
+            id: row.source === 'wof' ? parseInt(row.id, 10) : row.id,
+            source: row.source,
+            name: row.name,
+            abbr: row.abbr,
+            centroid: row.centroid,
+            bounding_box: row.bounding_box
+          }
+        })
     } else {
       delete resp[placetype]
     }


### PR DESCRIPTION
:wave: I did some awesome work for the Pelias project and would love for everyone to have a look at it and provide feedback.

---
#### Here's the reason for this change :rocket:
<!-- good place to use the magic github words that connect issues with PRs, like 
  - Fixes pelias/pelias#0000
  - Closes pelias/pelias#0000
  - Connected to pelias/pelias#0000
you can also just use good ol' words to explain what this does -->

I'm again trying to move forward on spatial and its use of multiple data sources. I'm now focusing on an API that would allow a client knowing PIP to choose whether or not they want sources external to WOF.

---
#### Here's what actually got changed :clap:
<!-- try listing some of the things in a nifty checklist
- [x] :cat:
- [ ] :dog:
- [x] :rabbit:
-->

Now, a client can add a header `x-wof-only` to add responses from other sources such as OSM. I also added some filters on name and id that are required.

I did a small test with postal codes, that was the easiest way, to make it to work, I changed the osm `boundary` tag from `postal_code` to `postalcode` on import.

WOF and OSM data `x-wof-only = false`
```http
GET /query/pip/_view/pelias/-62.8272498/17.8965958 HTTP 1.1
X-WOF-ONLY: false

{
    "postalcode": [
        {
            "bounding_box": "-62.859173,17.886295,-62.798313,17.917614",
            "centroid": {
                "lat": 17.903662,
                "lon": -62.8287673
            },
            "id": 421359555,
            "name": "97133",
            "source": "wof"
        },
        {
            "bounding_box": "-62.9511182,17.8708183,-62.7890273,17.9741033",
            "centroid": {
                "lat": 17.9036287,
                "lon": -62.8115689
            },
            "id": "relation:1363079",
            "name": "97133",
            "source": "osm"
        }
    ]
}
```

WOF only data `x-wof-only = true`
```http
GET /query/pip/_view/pelias/-62.8272498/17.8965958 HTTP 1.1
X-WOF-ONLY: true

{
    "postalcode": [
        {
            "bounding_box": "-62.859173,17.886295,-62.798313,17.917614",
            "centroid": {
                "lat": 17.903662,
                "lon": -62.8287673
            },
            "id": 421359555,
            "name": "97133",
            "source": "wof"
        }
    ]
}
```
