### PR TITLE
pip_verbose: add support for `lang` query parameter

### DIFF
--- a/module/pip/StatementPointInPolygonVerbose.js
+++ b/module/pip/StatementPointInPolygonVerbose.js
@@ -28,6 +28,16 @@ class StatementPeliasView extends SqliteStatement {
             LIMIT 1
           ) AS name,
           (
+            SELECT name
+            FROM name
+            WHERE source = place.source
+            AND id = place.id
+            AND lang = @lang
+            AND tag IN ('default', 'preferred')
+            AND abbr = 0
+            LIMIT 1
+          ) AS name_localized,
+          (
             SELECT GROUP_CONCAT(name, CHAR(30))
             FROM (
               SELECT name

--- a/server/routes/pip_verbose.js
+++ b/server/routes/pip_verbose.js
@@ -1,4 +1,7 @@
 const util = require('./util')
+const iso6393 = require('iso-639-3')
+const language = {}
+iso6393.filter(i => !!i.iso6391 && !!i.iso6393).forEach(i => { language[i.iso6391] = i.iso6393 })
 
 /**
  * a verbose view of the PIP data
@@ -9,13 +12,15 @@ const util = require('./util')
 module.exports = function (req, res) {
   var service = req.app.locals.service
 
+  const lang = util.flatten(req.query.lang)
   // inputs
   let query = {
     lon: parseFloat(util.flatten(req.query.lon)),
     lat: parseFloat(util.flatten(req.query.lat)),
     limit: 1000,
     aliaslimit: parseInt(util.flatten(req.query.aliaslimit), 10) || 0,
-    wofonly: util.flatten(req.query.wofonly) ? 1 : 0
+    wofonly: util.flatten(req.query.wofonly) ? 1 : 0,
+    lang: language[lang] || lang || 'und'
   }
 
   // perform query
@@ -27,20 +32,21 @@ module.exports = function (req, res) {
   let resp = {}
   rows.forEach(row => {
     let centroid = row.centroid.split(',').map(util.floatPrecision7)
+    let name = row.name_localized || row.name || undefined
 
     let nameAlias = []
     if (query.aliaslimit > 0) { nameAlias = (row.names || '').split(String.fromCharCode(30)) }
-    nameAlias = (nameAlias.length > 1) ? nameAlias.filter(n => n !== row.name).slice(0, query.aliaslimit) : undefined
+    nameAlias = (nameAlias.length > 1) ? nameAlias.filter(n => n !== name).slice(0, query.aliaslimit) : undefined
 
     let abbrAlias = []
     if (query.aliaslimit > 0) { abbrAlias = (row.abbrs || '').split(String.fromCharCode(30)) }
-    abbrAlias = (abbrAlias.length > 1) ? abbrAlias.filter(n => n !== row.name).slice(0, query.aliaslimit) : undefined
+    abbrAlias = (abbrAlias.length > 1) ? abbrAlias.filter(n => n !== name).slice(0, query.aliaslimit) : undefined
 
     if (!Array.isArray(resp[row.type])) { resp[row.type] = [] }
     resp[row.type].push({
       id: row.id,
       source: row.source,
-      name: row.name || undefined,
+      name: name,
       name_alias: nameAlias,
       abbr: row.abbr || undefined,
       abbr_alias: abbrAlias,


### PR DESCRIPTION
## Background

I was looking for inspiration to replace my PR #75 and found this API which seems to have a good base to be used as the default API (`/query/pip/verbose`). 

I know that we have some issue with multi-lang and autocomplete (see https://github.com/pelias/api/issues/1296), having parent members in a defined language may help those who need autocomplete to work in a different lang than English.

## What's new ?

I added a query parameter `lang` that accept iso 6391 (2 chars) and iso 6393 (3 chars) codes. Instead of using `und` lang it will return the requested language.
The name uses will not be in aliases when selected.

Small example from a request in France using Dutch `/query/pip/verbose?lon=2.344576377568282&lat=48.876457644366816&lang=nl`

```json
{
"country": [
    {
      "id": "85633147",
      "source": "wof",
      "name": "Frankrijk",
      "abbr": "FRA",
      "centroid": {
        "lat": 46.7153185,
        "lon": 2.1843152
      },
      "bounding_box": "-61.797841,-21.370782,55.854503,51.089382"
    }
  ],
  "localadmin": [
    {
      "id": "1159322569",
      "source": "wof",
      "name": "Parijs",
      "centroid": {
        "lat": 48.8590265,
        "lon": 2.3200487
      },
      "bounding_box": "2.224225,48.815607,2.469769,48.902008"
    }
  ]
}
```

closes #75 