### PR TITLE
pip_verbose: add support for `sources` query parameter

### DIFF
--- a/module/pip/StatementPointInPolygonVerbose.js
+++ b/module/pip/StatementPointInPolygonVerbose.js
@@ -82,8 +82,8 @@ class StatementPeliasView extends SqliteStatement {
         AND INTERSECTS( pip.geom, MakePoint( @lon, @lat, 4326 ) )
         AND (
           CASE
-            WHEN @wofonly <> 1 THEN 1
-            WHEN place.source = 'wof' THEN 1
+            WHEN @sources = '' THEN 1
+            WHEN @sources like '%' || CHAR(30) || place.source || CHAR(30) || '%' THEN 1
             ELSE 0
           END
         )

--- a/server/routes/pip_verbose.js
+++ b/server/routes/pip_verbose.js
@@ -1,6 +1,7 @@
 const util = require('./util')
 const iso6393 = require('iso-639-3')
 const language = {}
+const RECORD_SEPARATOR = String.fromCharCode(30)
 iso6393.filter(i => !!i.iso6391 && !!i.iso6393).forEach(i => { language[i.iso6391] = i.iso6393 })
 
 /**
@@ -13,13 +14,15 @@ module.exports = function (req, res) {
   var service = req.app.locals.service
 
   const lang = util.flatten(req.query.lang)
+  const sources = util.flatten(req.query.wofonly) ? ['wof'] : util.toSources(req.query.sources)
+
   // inputs
   let query = {
     lon: parseFloat(util.flatten(req.query.lon)),
     lat: parseFloat(util.flatten(req.query.lat)),
     limit: 1000,
     aliaslimit: parseInt(util.flatten(req.query.aliaslimit), 10) || 0,
-    wofonly: util.flatten(req.query.wofonly) ? 1 : 0,
+    sources: sources.length > 0 ? RECORD_SEPARATOR + sources.join(RECORD_SEPARATOR) + RECORD_SEPARATOR : '',
     lang: language[lang] || lang || 'und'
   }
 

--- a/server/routes/util.js
+++ b/server/routes/util.js
@@ -7,6 +7,11 @@ var namePreference = {
   tag: ['PREFERRED']
 }
 
+const sourceAlias = {
+  'whosonfirst': 'wof',
+  'openstreetmap': 'osm'
+}
+
 function scoreName (name) {
   var score = 0
   var idx = {
@@ -42,6 +47,17 @@ module.exports = {
     })
 
     return names[0].name
+  },
+  toSources (sources) {
+    if (!_.isString(sources)) {
+      return []
+    }
+    return sources
+      .split(',')
+      .map(str => _.trim(str))
+      .filter(str => !_.isEmpty(str))
+      .map(str => _.toLower(str))
+      .map(str => sourceAlias[str] || str)
   }
 }
 


### PR DESCRIPTION
## Background

Spatial works with different sources and this API can handle only wof and non-wof data only. So I decided to add a new parameter named `sources` (same name as pelias).

## What's new ?

This new query parameter will return only requested sources when present. It supports `openstreetmap` and `osm` for  compatibility with pelias services.

Small example from a request in France using OpenStreetMap 
```http
GET /query/pip/verbose?lon=2.344576377568282&lat=48.876457644366816&sources=osm
```
