### PR TITLE
import-osmium: should skip defaulted locales

### DIFF
--- a/import/source/osmium/map/names.js
+++ b/import/source/osmium/map/names.js
@@ -41,6 +41,7 @@ function mapper (place, properties) {
       if (lang.length === 2) {
         let locales = new locale.Locales(match[2])
         let best = locales.best(allLocales)
+        if (best.defaulted) { continue }
         lang = language[best.language].iso6393
       }
 


### PR DESCRIPTION
:wave: I did some awesome work for the Pelias project and would love for everyone to have a look at it and provide feedback.

---
#### Here's the reason for this change :rocket:
<!-- good place to use the magic github words that connect issues with PRs, like 
  - Fixes pelias/pelias#0000
  - Closes pelias/pelias#0000
  - Connected to pelias/pelias#0000
you can also just use good ol' words to explain what this does -->

I was importing data from OSM and found strange translations, Greek names affected to English.

Check this example [relation:530790](https://spatial.demo.geocode.earth/explore/place/osm/relation:530790)
![image](https://user-images.githubusercontent.com/5153882/209801250-33718cf5-f9d7-41f2-9289-6197a654fbee.png)

As you can see, `Ηρακλειά` is saved as Greek and English name, when you go on osm.org, the tags of the relation [osm.org/relation/530790](https://www.openstreetmap.org/relation/530790) are (I filtered only names and yes data from the screenshot are outdated)

tag | value
-- | --
alt_name:fr|Irakliá
int_name|Iraklia
name|Ηρακλειά
name:ca|Iràklia
name:de|Iraklia
name:el|Ηρακλειά
name:en|Iraklia
name:fr|Héraclée
name:gr|Ηρακλειά

I found the part of the code that generated this issue, it is the following.

https://github.com/pelias/spatial/blob/416b5c7e05594b802ca43e12a9e00d4146d22e8e/import/source/osmium/map/names.js#L41-L45

The tag `name:gr` is affected to the default language (English in this example). Since the language `gr` does not exists (Greek iso code is `el`), the library `locale` returns the default locale which is computer one or English.

I feel like using `locale` is unnecessary here since we are filtering on iso639-1 codes (two letters) with a dictionary of supported languages from `iso-639-3`.... 

I have an export of all `*name:*` tags found for administrative boundaries from OSM: [osm_names.txt](https://github.com/pelias/spatial/files/10313909/osm_names.txt)

---
#### Here's what actually got changed :clap:
<!-- try listing some of the things in a nifty checklist
- [x] :cat:
- [ ] :dog:
- [x] :rabbit:
-->

In this PR I will only skip when the best language is the default one, this will avoid wrong translations. Maybe the next step will be remove `locale` and use `language[lang]` instead ?
