### PR TITLE
wof-import: convert iso2 abbr to iso3 for countries and dependencies

### DIFF
--- a/import/source/whosonfirst/config/generic.js
+++ b/import/source/whosonfirst/config/generic.js
@@ -1,4 +1,5 @@
 const _ = require('lodash')
+const iso3166 = require('iso3166-1')
 
 /**
  * This file provides some convenience functions for finding the 'generic name'
@@ -38,6 +39,13 @@ function getName (properties) {
   if (name) { return name.trim() }
 }
 
+function toIso3Abbreviation (abbr, placetype) {
+  if ((placetype === 'country' || placetype === 'dependency') && iso3166.is2(abbr)) {
+    return iso3166.to3(abbr)
+  }
+  return abbr
+}
+
 // convenience function to find a generic abbreviation for the place
 function getAbbreviation (properties) {
   const placeType = _.get(properties, 'wof:placetype')
@@ -48,18 +56,18 @@ function getAbbreviation (properties) {
 
   // use the 3 letter country code for 'country' placetypes
   if (placeType === 'country' && countryCode) {
-    return countryCode.trim()
+    return toIso3Abbreviation(countryCode.trim(), placeType)
   }
 
   // use shortcode
-  if (shortCode) { return shortCode.trim() }
+  if (shortCode) { return toIso3Abbreviation(shortCode.trim(), placeType) }
 
   // use abbreviation
-  if (abbreviation) { return abbreviation.trim() }
+  if (abbreviation) { return toIso3Abbreviation(abbreviation.trim(), placeType) }
 
   // support the deprecated 'wof:country' field
   if (placeType === 'dependency' && country) {
-    return country.trim()
+    return toIso3Abbreviation(country.trim(), placeType)
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "express-handlebars": "^3.1.0",
     "handlebars-helpers": "^0.10.0",
     "iso-639-3": "^1.2.0",
+    "iso3166-1": "^0.5.1",
     "locale": "^0.1.0",
     "lodash": "^4.17.15",
     "morgan": "^1.9.1",


### PR DESCRIPTION
I'm trying to add more consistency in abbreviations. In WOF data we can find countries and dependencies with iso2 and iso3 abbreviations.

In [pelias/whosonfirst](https://github.com/pelias/whosonfirst/) we are using only iso3 abbreviation, I'm porting this feature to spatial (see [pelias/whosonfirst/peliasDocGenerators.js](https://github.com/pelias/whosonfirst/blob/22f7ad76dbf65bf25f0f4a2af352ad45b72a2a94/src/peliasDocGenerators.js#L41-L55))