### PR TITLE
Effectively remove limit on returned names

### DIFF
--- a/server/routes/name.js
+++ b/server/routes/name.js
@@ -7,7 +7,7 @@ module.exports = function (req, res) {
   let query = {
     source: util.flatten(req.params.source),
     id: util.flatten(req.params.id),
-    limit: 100
+    limit: 1000000
   }
 
   // perform query


### PR DESCRIPTION
Hello! I'm using the spatial server for a toy geocoder I'm working on and I ran into a limitation with the names endpoint that led to some very weird bugs (missing names in certain languages). Eventually I figured out that it's only returning 100 names. I can't imagine any use-case where I would want a random subset of names that a place has, so I bumped the limit up really high. There's probably a better way to do this but I thought I'd open the PR and ask about it anyway :)