### PR TITLE
fix for unknown placetypes (ie. not in spec file)

### DIFF
--- a/import/source/whosonfirst/map/hierarchies.js
+++ b/import/source/whosonfirst/map/hierarchies.js
@@ -7,7 +7,10 @@ const Hierarchy = require('../../../../model/Hierarchy')
 function sortHierarchy (hierarchy) {
   return _(hierarchy)
     .toPairs()
-    .sortBy(([k]) => spec.names.get(k.replace('_id', '')).rank || 0)
+    .sortBy(([k]) => {
+      const placetype = spec.names.get(k.replace('_id', ''))
+      return placetype ? placetype.rank : 0
+    })
     .reverse()
     .fromPairs()
     .value()

--- a/import/source/whosonfirst/map/hierarchies.test.js
+++ b/import/source/whosonfirst/map/hierarchies.test.js
@@ -111,3 +111,24 @@ tap.test('mapper: key ordering', (t) => {
   ])
   t.end()
 })
+tap.test('mapper: sort hierarchy - unknown placetype', (t) => {
+  const p = new Place(new Identity('wof', '1729339019'), new Ontology('admin', 'locality'))
+  map(p, {
+    'wof:hierarchy': [
+      {
+        region_id: 85687233,
+        unknown_id: 1
+      }
+    ]
+  })
+
+  t.equal(p.hierarchy.length, 1)
+  t.same(p.hierarchy, [
+    new Hierarchy(
+      new Identity('wof', '1729339019'),
+      new Identity('wof', '85687233'),
+      'wof:0'
+    )
+  ])
+  t.end()
+})


### PR DESCRIPTION
It seems that the `whosonfirst/whosonfirst-placetypes/master/data/placetypes-spec-latest.json` file is not consistent and may contain omissions.

This PR fixes the following error message by assuming unknown placetypes are of rank 0.

Going-forward we may need to abandon the idea of using this spec file, in an ideal world it would provide a tree view of the whosonfirst placetype hierarchy, although it doesn't seem to be complete, I also found a bug today that the `constituency` placetype was removed by accident, so It's unclear what other issues it might contain.

```bash
mapping error TypeError: Cannot read properties of undefined (reading 'rank')
    at /code/import/source/whosonfirst/map/hierarchies.js:10:58
    at /code/node_modules/lodash/lodash.js:3782:18
    at arrayMap (/code/node_modules/lodash/lodash.js:653:23)
    at /code/node_modules/lodash/lodash.js:3781:24
    at /code/node_modules/lodash/lodash.js:3585:27
    at /code/node_modules/lodash/lodash.js:4943:15
    at baseMap (/code/node_modules/lodash/lodash.js:3584:7)
    at baseOrderBy (/code/node_modules/lodash/lodash.js:3780:20)
    at Function.<anonymous> (/code/node_modules/lodash/lodash.js:10007:14)
    at apply (/code/node_modules/lodash/lodash.js:489:27)
```