### PR TITLE
explicit WOF hierarchies

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -1,6 +1,6 @@
 {
   "node": true,
-  "esversion": 6,
+  "esversion": 9,
   "curly": true,
   "latedef": "nofunc",
   "quotmark": true,

--- a/import/source/whosonfirst/map/hierarchies.js
+++ b/import/source/whosonfirst/map/hierarchies.js
@@ -19,31 +19,25 @@ function sortHierarchy (hierarchy) {
 function mapper (place, properties) {
   const hierarchies = _.get(properties, 'wof:hierarchy', [])
   const pt = spec.names.get(place.ontology.type)
-  const validParentPlaceTypes = spec.parents(place.ontology.type).reduce((memo, item) => {
-    memo[item.name] = item
-    return memo
-  }, {})
+  const id = parseInt(place.identity.id, 10)
 
   hierarchies.forEach((hierarchy, o) => {
-    for (const key in sortHierarchy(hierarchy)) {
-      const placetype = key.replace('_id', '')
-      if (!validParentPlaceTypes.hasOwnProperty(placetype)) { continue } // not a valid parent type
-      if (validParentPlaceTypes[placetype].name === pt.name) { continue } // same placetype
-      if (validParentPlaceTypes[placetype].rank >= pt.rank) { continue } // same or less granular
+    // sort hierarchy and ensure self-reference exists
+    const sorted = sortHierarchy({ ...hierarchy, ...{ [`${pt.name}_id`]: id } })
 
+    let depth = 0
+    for (const key in sorted) {
       place.addHierarchy(
         new Hierarchy(
           place.identity,
           new Identity(
             place.identity.source,
-            hierarchy[key].toString()
+            sorted[key].toString()
           ),
-          `wof:${o}`
+          `wof:${o}`,
+          depth++
         )
       )
-      // only take the first (must be the lowest level) parent
-      // ensures we only get a max of one parent per hierarchy
-      break
     }
   })
 }

--- a/import/source/whosonfirst/map/hierarchies.test.js
+++ b/import/source/whosonfirst/map/hierarchies.test.js
@@ -45,11 +45,13 @@ tap.test('mapper: single hierarchy', (t) => {
     ]
   })
 
-  t.equal(p.hierarchy.length, 1)
-  t.equal(p.hierarchy[0].child, fixture.locality.identity)
-  t.equal(p.hierarchy[0].parent.source, fixture.locality.identity.source)
-  t.equal(p.hierarchy[0].parent.id, '102062861')
-  t.equal(p.hierarchy[0].branch, 'wof:0')
+  t.same([
+    new Hierarchy(p.identity, p.identity, 'wof:0', 0),
+    new Hierarchy(p.identity, new Identity('wof', '102062861'), 'wof:0', 1),
+    new Hierarchy(p.identity, new Identity('wof', '85682381'), 'wof:0', 2),
+    new Hierarchy(p.identity, new Identity('wof', '85633051'), 'wof:0', 3),
+    new Hierarchy(p.identity, new Identity('wof', '102191581'), 'wof:0', 4)
+  ], p.hierarchy)
   t.end()
 })
 tap.test('mapper: multiple hierarchies', (t) => {
@@ -72,17 +74,18 @@ tap.test('mapper: multiple hierarchies', (t) => {
     ]
   })
 
-  t.equal(p.hierarchy.length, 2)
+  t.same([
+    new Hierarchy(p.identity, p.identity, 'wof:0', 0),
+    new Hierarchy(p.identity, new Identity('wof', '1159339547'), 'wof:0', 1),
+    new Hierarchy(p.identity, new Identity('wof', '85632685'), 'wof:0', 2),
+    new Hierarchy(p.identity, new Identity('wof', '874393555'), 'wof:0', 3),
+    new Hierarchy(p.identity, new Identity('wof', '102191581'), 'wof:0', 4),
 
-  t.equal(p.hierarchy[0].child, fixture.region.identity)
-  t.equal(p.hierarchy[0].parent.source, fixture.region.identity.source)
-  t.equal(p.hierarchy[0].parent.id, '1159339547')
-  t.equal(p.hierarchy[0].branch, 'wof:0')
-
-  t.equal(p.hierarchy[1].child, fixture.region.identity)
-  t.equal(p.hierarchy[1].parent.source, fixture.region.identity.source)
-  t.equal(p.hierarchy[1].parent.id, '1159339547')
-  t.equal(p.hierarchy[1].branch, 'wof:1')
+    new Hierarchy(p.identity, p.identity, 'wof:1', 0),
+    new Hierarchy(p.identity, new Identity('wof', '1159339547'), 'wof:1', 1),
+    new Hierarchy(p.identity, new Identity('wof', '85633805'), 'wof:1', 2),
+    new Hierarchy(p.identity, new Identity('wof', '102191581'), 'wof:1', 3)
+  ], p.hierarchy)
 
   t.end()
 })
@@ -101,14 +104,15 @@ tap.test('mapper: key ordering', (t) => {
     ]
   })
 
-  t.equal(p.hierarchy.length, 1)
-  t.same(p.hierarchy, [
-    new Hierarchy(
-      new Identity('wof', '1729339019'),
-      new Identity('wof', '1729238583'),
-      'wof:0'
-    )
-  ])
+  t.same([
+    new Hierarchy(p.identity, p.identity, 'wof:0', 0),
+    new Hierarchy(p.identity, new Identity('wof', '1729238583'), 'wof:0', 1),
+    new Hierarchy(p.identity, new Identity('wof', '102079339'), 'wof:0', 2),
+    new Hierarchy(p.identity, new Identity('wof', '85687233'), 'wof:0', 3),
+    new Hierarchy(p.identity, new Identity('wof', '85633345'), 'wof:0', 4),
+    new Hierarchy(p.identity, new Identity('wof', '102191583'), 'wof:0', 5)
+  ], p.hierarchy)
+
   t.end()
 })
 tap.test('mapper: sort hierarchy - unknown placetype', (t) => {
@@ -122,13 +126,11 @@ tap.test('mapper: sort hierarchy - unknown placetype', (t) => {
     ]
   })
 
-  t.equal(p.hierarchy.length, 1)
-  t.same(p.hierarchy, [
-    new Hierarchy(
-      new Identity('wof', '1729339019'),
-      new Identity('wof', '85687233'),
-      'wof:0'
-    )
-  ])
+  t.same([
+    new Hierarchy(p.identity, p.identity, 'wof:0', 0),
+    new Hierarchy(p.identity, new Identity('wof', '85687233'), 'wof:0', 1),
+    new Hierarchy(p.identity, new Identity('wof', '1'), 'wof:0', 2)
+  ], p.hierarchy)
+
   t.end()
 })

--- a/model/Hierarchy.js
+++ b/model/Hierarchy.js
@@ -2,10 +2,11 @@ const _ = require('lodash')
 const Identity = require('./Identity')
 
 class Hierarchy {
-  constructor (child, parent, branch) {
+  constructor (child, parent, branch, depth = Hierarchy.UNKNOWN_DEPTH) {
     this.setChild(child)
     this.setParent(parent)
     this.setBranch(branch)
+    this.setDepth(depth)
   }
   setChild (child) {
     if (child instanceof Identity && child._isValid()) {
@@ -22,12 +23,20 @@ class Hierarchy {
       this.branch = branch
     }
   }
+  setDepth (depth) {
+    if (_.isNumber(depth)) {
+      this.depth = depth
+    }
+  }
   _isValid () {
     if (!(this.child instanceof Identity)) { return false }
     if (!(this.parent instanceof Identity)) { return false }
     if (!_.isString(this.branch) || !this.branch.length) { return false }
+    if (!_.isNumber(this.depth)) { return false }
     return true
   }
 }
+
+Hierarchy.UNKNOWN_DEPTH = -1
 
 module.exports = Hierarchy

--- a/model/Hierarchy.test.js
+++ b/model/Hierarchy.test.js
@@ -13,6 +13,7 @@ tap.test('constructor: empty', (t) => {
   t.equal(h.child, undefined)
   t.equal(h.parent, undefined)
   t.equal(h.branch, undefined)
+  t.equal(h.depth, Hierarchy.UNKNOWN_DEPTH)
   t.end()
 })
 tap.test('constructor: child only', (t) => {
@@ -20,6 +21,7 @@ tap.test('constructor: child only', (t) => {
   t.equal(h.child, fixture.child)
   t.equal(h.parent, undefined)
   t.equal(h.branch, undefined)
+  t.equal(h.depth, Hierarchy.UNKNOWN_DEPTH)
   t.end()
 })
 tap.test('constructor: parent only', (t) => {
@@ -27,6 +29,7 @@ tap.test('constructor: parent only', (t) => {
   t.equal(h.child, undefined)
   t.equal(h.parent, fixture.parent)
   t.equal(h.branch, undefined)
+  t.equal(h.depth, Hierarchy.UNKNOWN_DEPTH)
   t.end()
 })
 tap.test('constructor: branch only', (t) => {
@@ -34,6 +37,7 @@ tap.test('constructor: branch only', (t) => {
   t.equal(h.child, undefined)
   t.equal(h.parent, undefined)
   t.equal(h.branch, 'example')
+  t.equal(h.depth, Hierarchy.UNKNOWN_DEPTH)
   t.end()
 })
 tap.test('constructor: child, parent & branch', (t) => {
@@ -41,6 +45,15 @@ tap.test('constructor: child, parent & branch', (t) => {
   t.equal(h.child, fixture.child)
   t.equal(h.parent, fixture.parent)
   t.equal(h.branch, 'example')
+  t.equal(h.depth, Hierarchy.UNKNOWN_DEPTH)
+  t.end()
+})
+tap.test('constructor: child, parent, branch & depth', (t) => {
+  let h = new Hierarchy(fixture.child, fixture.parent, 'example', 0)
+  t.equal(h.child, fixture.child)
+  t.equal(h.parent, fixture.parent)
+  t.equal(h.branch, 'example')
+  t.equal(h.depth, 0)
   t.end()
 })
 
@@ -189,6 +202,11 @@ tap.test('isValid: empty parent', (t) => {
 })
 tap.test('isValid: empty branch', (t) => {
   let h = new Hierarchy(fixture.child, fixture.parent, undefined)
+  t.notOk(h._isValid())
+  t.end()
+})
+tap.test('isValid: invalid depth', (t) => {
+  let h = new Hierarchy(fixture.child, fixture.parent, 'example', 'stringvalue')
   t.notOk(h._isValid())
   t.end()
 })

--- a/module/hierarchy/HierarchyModule.js
+++ b/module/hierarchy/HierarchyModule.js
@@ -4,10 +4,10 @@ const IndexUnique = require('./IndexUnique')
 const IndexChildIdentity = require('./IndexChildIdentity')
 const IndexParentIdentity = require('./IndexParentIdentity')
 const IndexPipPerformance = require('./IndexPipPerformance')
-const StatementInsert = require('./StatementInsert')
+const StatementInsertParent = require('./StatementInsertParent')
 const StatementFetch = require('./StatementFetch')
-const ViewInsertProxy = require('./ViewInsertProxy')
-const TriggerOnInsert = require('./TriggerOnInsert')
+const ViewInsertParent = require('./ViewInsertParent')
+const TriggerOnInsertParent = require('./TriggerOnInsertParent')
 
 class HierarchyModule extends Module {
   constructor (db) {
@@ -22,21 +22,21 @@ class HierarchyModule extends Module {
       pipPerformance: new IndexPipPerformance()
     }
     this.statement = {
-      insert: new StatementInsert(),
+      insertParent: new StatementInsertParent(),
       fetch: new StatementFetch()
     }
     this.trigger = {
-      onInsert: new TriggerOnInsert()
+      onInsertParent: new TriggerOnInsertParent()
     }
     this.view = {
-      insertProxy: new ViewInsertProxy()
+      insertParent: new ViewInsertParent()
     }
   }
   insert (place) {
     let info = { changes: 0, lastInsertRowid: 0 }
     place.hierarchy.forEach(hierarchy => {
       // insert hierarchy
-      let _info = this.statement.insert.run({
+      let _info = this.statement.insertParent.run({
         child_source: hierarchy.child.source,
         child_id: hierarchy.child.id,
         parent_source: hierarchy.parent.source,

--- a/module/hierarchy/HierarchyModule.js
+++ b/module/hierarchy/HierarchyModule.js
@@ -1,9 +1,12 @@
+const _ = require('lodash')
 const Module = require('../Module')
+const Hierarchy = require('../../model/Hierarchy')
 const TableHierarchy = require('./TableHierarchy')
 const IndexUnique = require('./IndexUnique')
 const IndexChildIdentity = require('./IndexChildIdentity')
 const IndexParentIdentity = require('./IndexParentIdentity')
 const IndexPipPerformance = require('./IndexPipPerformance')
+const StatementInsert = require('./StatementInsert')
 const StatementInsertParent = require('./StatementInsertParent')
 const StatementFetch = require('./StatementFetch')
 const ViewInsertParent = require('./ViewInsertParent')
@@ -22,6 +25,7 @@ class HierarchyModule extends Module {
       pipPerformance: new IndexPipPerformance()
     }
     this.statement = {
+      insert: new StatementInsert(),
       insertParent: new StatementInsertParent(),
       fetch: new StatementFetch()
     }
@@ -34,19 +38,27 @@ class HierarchyModule extends Module {
   }
   insert (place) {
     let info = { changes: 0, lastInsertRowid: 0 }
+
     place.hierarchy.forEach(hierarchy => {
-      // insert hierarchy
-      let _info = this.statement.insertParent.run({
+      let args = {
         child_source: hierarchy.child.source,
         child_id: hierarchy.child.id,
         parent_source: hierarchy.parent.source,
         parent_id: hierarchy.parent.id,
         branch: hierarchy.branch
-      })
+      }
 
-      // update aggregate info
-      info.changes += _info.changes
-      info.lastInsertRowid = _info.lastInsertRowid
+      // we support two different hierarchy insertion methods
+      // one where the depth is unknown and the parent hierarchy
+      // is automatically generated, the second method is where
+      // the depth is known. Each method uses a different query.
+
+      // insert hierarchy, update aggregate info
+      if (hierarchy.depth === Hierarchy.UNKNOWN_DEPTH) {
+        _.extend(info, this.statement.insertParent.run(args))
+      } else {
+        _.extend(info, this.statement.insert.run({ ...args, depth: hierarchy.depth }))
+      }
     })
     return info
   }

--- a/module/hierarchy/StatementFetch.test.js
+++ b/module/hierarchy/StatementFetch.test.js
@@ -2,9 +2,9 @@ const tap = require('tap')
 const common = require('../../test/common')
 const TableHierarchy = require('./TableHierarchy')
 const IndexUnique = require('./IndexUnique')
-const ViewInsertProxy = require('./ViewInsertProxy')
-const TriggerOnInsert = require('./TriggerOnInsert')
-const StatementInsert = require('./StatementInsert')
+const ViewInsertParent = require('./ViewInsertParent')
+const TriggerOnInsertParent = require('./TriggerOnInsertParent')
+const StatementInsert = require('./StatementInsertParent')
 const StatementFetch = require('./StatementFetch')
 
 tap.test('function', (t) => {
@@ -19,11 +19,11 @@ tap.test('function', (t) => {
   idx.create(db)
 
   // create view
-  let view = new ViewInsertProxy()
+  let view = new ViewInsertParent()
   view.create(db)
 
   // create view
-  let trigger = new TriggerOnInsert()
+  let trigger = new TriggerOnInsertParent()
   trigger.create(db)
 
   // prepare statement

--- a/module/hierarchy/StatementInsert.js
+++ b/module/hierarchy/StatementInsert.js
@@ -1,0 +1,39 @@
+const _ = require('lodash')
+const SqliteStatement = require('../../sqlite/SqliteStatement')
+
+/**
+ * When inserting hierarchy entries manuually (ie. instead of
+ * using the InsertParent view.) some care needs to be taken to:
+ *
+ * - Create a self-referencing entry at depth=0
+ * - Manually assign the correct depth values for each entry
+ */
+
+class StatementInsert extends SqliteStatement {
+  create (db, config) {
+    try {
+      let dbname = _.get(config, 'database', 'main')
+      this.statement = db.prepare(`
+        INSERT OR IGNORE INTO ${dbname}.hierarchy (
+          parent_source,
+          parent_id,
+          child_source,
+          child_id,
+          depth,
+          branch
+        ) VALUES (
+          @parent_source,
+          @parent_id,
+          @child_source,
+          @child_id,
+          @depth,
+          @branch
+        )
+      `)
+    } catch (e) {
+      this.error('PREPARE STATEMENT', e)
+    }
+  }
+}
+
+module.exports = StatementInsert

--- a/module/hierarchy/StatementInsert.test.js
+++ b/module/hierarchy/StatementInsert.test.js
@@ -1,0 +1,162 @@
+const tap = require('tap')
+const common = require('../../test/common')
+const TableHierarchy = require('./TableHierarchy')
+const StatementInsert = require('./StatementInsert')
+const IndexUnique = require('./IndexUnique')
+
+tap.test('single insert', (t) => {
+  let db = common.tempDatabase()
+
+  // create table
+  let table = new TableHierarchy()
+  table.create(db)
+
+  // create index
+  let idx = new IndexUnique()
+  idx.create(db)
+
+  // prepare statement
+  let stmt = new StatementInsert()
+  stmt.create(db)
+
+  // table empty
+  t.notOk(db.prepare(`SELECT * FROM hierarchy`).all().length, 'prior state')
+
+  // insert data
+  let info = stmt.run({
+    parent_source: 'example_parent_source',
+    parent_id: 'example_parent_id',
+    child_source: 'example_child_source',
+    child_id: 'example_child_id',
+    depth: 1,
+    branch: 'default'
+  })
+
+  // insert info
+  t.same(info, { changes: 1, lastInsertRowid: 1 }, 'write')
+
+  // read data
+  t.same(db.prepare(`SELECT * FROM hierarchy`).all(), [{
+    parent_source: 'example_parent_source',
+    parent_id: 'example_parent_id',
+    child_source: 'example_child_source',
+    child_id: 'example_child_id',
+    depth: 1,
+    branch: 'default'
+  }],
+  'read')
+
+  t.end()
+})
+tap.test('add parent', (t) => {
+  let db = common.tempDatabase()
+
+  // create table
+  let table = new TableHierarchy()
+  table.create(db)
+
+  // create index
+  let idx = new IndexUnique()
+  idx.create(db)
+
+  // prepare statement
+  let stmt = new StatementInsert()
+  stmt.create(db)
+
+  // table empty
+  t.notOk(db.prepare(`SELECT * FROM hierarchy`).all().length, 'prior state')
+
+  // insert data
+  stmt.run({
+    parent_source: 'example_parent_source',
+    parent_id: 'example_parent_id',
+    child_source: 'example_child_source',
+    child_id: 'example_child_id',
+    depth: 1,
+    branch: 'default'
+  })
+  stmt.run({
+    parent_source: 'example_super_parent_source',
+    parent_id: 'example_super_parent_id',
+    child_source: 'example_child_source',
+    child_id: 'example_child_id',
+    depth: 2,
+    branch: 'default'
+  })
+
+  // read data
+  t.same(db.prepare(`SELECT * FROM hierarchy`).all(), [{
+    parent_source: 'example_parent_source',
+    parent_id: 'example_parent_id',
+    child_source: 'example_child_source',
+    child_id: 'example_child_id',
+    depth: 1,
+    branch: 'default'
+  }, {
+    parent_source: 'example_super_parent_source',
+    parent_id: 'example_super_parent_id',
+    child_source: 'example_child_source',
+    child_id: 'example_child_id',
+    depth: 2,
+    branch: 'default'
+  }],
+  'read')
+
+  t.end()
+})
+tap.test('add child', (t) => {
+  let db = common.tempDatabase()
+
+  // create table
+  let table = new TableHierarchy()
+  table.create(db)
+
+  // create index
+  let idx = new IndexUnique()
+  idx.create(db)
+
+  // prepare statement
+  let stmt = new StatementInsert()
+  stmt.create(db)
+
+  // table empty
+  t.notOk(db.prepare(`SELECT * FROM hierarchy`).all().length, 'prior state')
+
+  // insert data
+  stmt.run({
+    parent_source: 'example_super_parent_source',
+    parent_id: 'example_super_parent_id',
+    child_source: 'example_child_source',
+    child_id: 'example_child_id',
+    depth: 2,
+    branch: 'default'
+  })
+  stmt.run({
+    parent_source: 'example_parent_source',
+    parent_id: 'example_parent_id',
+    child_source: 'example_child_source',
+    child_id: 'example_child_id',
+    depth: 1,
+    branch: 'default'
+  })
+
+  // read data
+  t.same(db.prepare(`SELECT * FROM hierarchy`).all(), [{
+    parent_source: 'example_super_parent_source',
+    parent_id: 'example_super_parent_id',
+    child_source: 'example_child_source',
+    child_id: 'example_child_id',
+    depth: 2,
+    branch: 'default'
+  }, {
+    parent_source: 'example_parent_source',
+    parent_id: 'example_parent_id',
+    child_source: 'example_child_source',
+    child_id: 'example_child_id',
+    depth: 1,
+    branch: 'default'
+  }],
+  'read')
+
+  t.end()
+})

--- a/module/hierarchy/StatementInsertParent.js
+++ b/module/hierarchy/StatementInsertParent.js
@@ -1,12 +1,12 @@
 const _ = require('lodash')
 const SqliteStatement = require('../../sqlite/SqliteStatement')
 
-class StatementInsert extends SqliteStatement {
+class StatementInsertParent extends SqliteStatement {
   create (db, config) {
     try {
       let dbname = _.get(config, 'database', 'main')
       this.statement = db.prepare(`
-        INSERT OR IGNORE INTO ${dbname}.hierarchy_insert_proxy (
+        INSERT OR IGNORE INTO ${dbname}.hierarchy_insert_parent (
           parent_source,
           parent_id,
           child_source,
@@ -26,4 +26,4 @@ class StatementInsert extends SqliteStatement {
   }
 }
 
-module.exports = StatementInsert
+module.exports = StatementInsertParent

--- a/module/hierarchy/StatementInsertParent.test.js
+++ b/module/hierarchy/StatementInsertParent.test.js
@@ -1,9 +1,9 @@
 const tap = require('tap')
 const common = require('../../test/common')
 const TableHierarchy = require('./TableHierarchy')
-const ViewInsertProxy = require('./ViewInsertProxy')
-const TriggerOnInsert = require('./TriggerOnInsert')
-const StatementInsert = require('./StatementInsert')
+const ViewInsertParent = require('./ViewInsertParent')
+const TriggerOnInsertParent = require('./TriggerOnInsertParent')
+const StatementInsertParent = require('./StatementInsertParent')
 const IndexUnique = require('./IndexUnique')
 
 tap.test('single insert', (t) => {
@@ -18,15 +18,15 @@ tap.test('single insert', (t) => {
   idx.create(db)
 
   // create view
-  let view = new ViewInsertProxy()
+  let view = new ViewInsertParent()
   view.create(db)
 
   // create trigger
-  let trigger = new TriggerOnInsert()
+  let trigger = new TriggerOnInsertParent()
   trigger.create(db)
 
   // prepare statement
-  let stmt = new StatementInsert()
+  let stmt = new StatementInsertParent()
   stmt.create(db)
 
   // table empty
@@ -84,15 +84,15 @@ tap.test('add parent', (t) => {
   idx.create(db)
 
   // create view
-  let view = new ViewInsertProxy()
+  let view = new ViewInsertParent()
   view.create(db)
 
   // create trigger
-  let trigger = new TriggerOnInsert()
+  let trigger = new TriggerOnInsertParent()
   trigger.create(db)
 
   // prepare statement
-  let stmt = new StatementInsert()
+  let stmt = new StatementInsertParent()
   stmt.create(db)
 
   // table empty
@@ -174,15 +174,15 @@ tap.test('add child', (t) => {
   idx.create(db)
 
   // create view
-  let view = new ViewInsertProxy()
+  let view = new ViewInsertParent()
   view.create(db)
 
   // create view
-  let trigger = new TriggerOnInsert()
+  let trigger = new TriggerOnInsertParent()
   trigger.create(db)
 
   // prepare statement
-  let stmt = new StatementInsert()
+  let stmt = new StatementInsertParent()
   stmt.create(db)
 
   // table empty

--- a/module/hierarchy/TriggerOnInsertParent.test.js
+++ b/module/hierarchy/TriggerOnInsertParent.test.js
@@ -2,8 +2,8 @@ const tap = require('tap')
 const common = require('../../test/common')
 const SqliteIntrospect = require('../../sqlite/SqliteIntrospect')
 const TableHierarchy = require('./TableHierarchy')
-const ViewInsertProxy = require('./ViewInsertProxy')
-const TriggerOnInsert = require('./TriggerOnInsert')
+const ViewInsertParent = require('./ViewInsertParent')
+const TriggerOnInsertParent = require('./TriggerOnInsertParent')
 const IndexUnique = require('./IndexUnique')
 
 tap.test('create & drop', (t) => {
@@ -19,24 +19,24 @@ tap.test('create & drop', (t) => {
   idx.create(db)
 
   // create view
-  let view = new ViewInsertProxy()
+  let view = new ViewInsertParent()
   view.create(db)
 
   // trigger does not exist
-  t.notOk(introspect.triggers('hierarchy_insert_proxy').length, 'prior state')
+  t.notOk(introspect.triggers('hierarchy_insert_parent').length, 'prior state')
 
   // create trigger
-  let trigger = new TriggerOnInsert()
+  let trigger = new TriggerOnInsertParent()
   trigger.create(db)
 
   // trigger exists
-  t.ok(introspect.triggers('hierarchy_insert_proxy').length, 'create')
+  t.ok(introspect.triggers('hierarchy_insert_parent').length, 'create')
 
   // drop trigger
   trigger.drop(db)
 
   // trigger does not exist
-  t.notOk(introspect.triggers('hierarchy_insert_proxy').length, 'drop')
+  t.notOk(introspect.triggers('hierarchy_insert_parent').length, 'drop')
 
   t.end()
 })
@@ -54,25 +54,25 @@ tap.test('definition', (t) => {
   idx.create(db)
 
   // create view
-  let view = new ViewInsertProxy()
+  let view = new ViewInsertParent()
   view.create(db)
 
   // create trigger
-  let trigger = new TriggerOnInsert()
+  let trigger = new TriggerOnInsertParent()
   trigger.create(db)
 
   // test triggers
-  let triggers = introspect.triggers('hierarchy_insert_proxy')
+  let triggers = introspect.triggers('hierarchy_insert_parent')
 
   // hierarchy_idx_covering
   t.same(triggers[0], {
     type: 'trigger',
     name: 'hierarchy_on_insert_trigger',
-    tbl_name: 'hierarchy_insert_proxy',
+    tbl_name: 'hierarchy_insert_parent',
     rootpage: 0,
     sql: `
         CREATE TRIGGER IF NOT EXISTS hierarchy_on_insert_trigger
-        INSTEAD OF INSERT ON main.hierarchy_insert_proxy
+        INSTEAD OF INSERT ON main.hierarchy_insert_parent
         BEGIN
 
           /* insert self-reference for parent at depth 0 */

--- a/module/hierarchy/ViewInsertParent.js
+++ b/module/hierarchy/ViewInsertParent.js
@@ -1,12 +1,12 @@
 const _ = require('lodash')
 const SqliteIndex = require('../../sqlite/SqliteIndex')
 
-class ViewInsertProxy extends SqliteIndex {
+class ViewInsertParent extends SqliteIndex {
   create (db, config) {
     try {
       let dbname = _.get(config, 'database', 'main')
       db.prepare(`
-        CREATE VIEW IF NOT EXISTS ${dbname}.hierarchy_insert_proxy AS
+        CREATE VIEW IF NOT EXISTS ${dbname}.hierarchy_insert_parent AS
         SELECT * FROM hierarchy
       `).run()
     } catch (e) {
@@ -17,7 +17,7 @@ class ViewInsertProxy extends SqliteIndex {
     try {
       let dbname = _.get(config, 'database', 'main')
       db.prepare(`
-        DROP VIEW IF EXISTS ${dbname}.hierarchy_insert_proxy
+        DROP VIEW IF EXISTS ${dbname}.hierarchy_insert_parent
       `).run()
     } catch (e) {
       this.error('DROP VIEW', e)
@@ -25,4 +25,4 @@ class ViewInsertProxy extends SqliteIndex {
   }
 }
 
-module.exports = ViewInsertProxy
+module.exports = ViewInsertParent

--- a/module/hierarchy/ViewInsertParent.test.js
+++ b/module/hierarchy/ViewInsertParent.test.js
@@ -2,7 +2,7 @@ const tap = require('tap')
 const common = require('../../test/common')
 const SqliteIntrospect = require('../../sqlite/SqliteIntrospect')
 const TableHierarchy = require('./TableHierarchy')
-const ViewInsertProxy = require('./ViewInsertProxy')
+const ViewInsertParent = require('./ViewInsertParent')
 
 tap.test('create & drop', (t) => {
   let db = common.tempDatabase()
@@ -13,20 +13,20 @@ tap.test('create & drop', (t) => {
   table.create(db)
 
   // column does not exist
-  t.notOk(introspect.views('hierarchy_insert_proxy').length, 'prior state')
+  t.notOk(introspect.views('hierarchy_insert_parent').length, 'prior state')
 
   // create index
-  let index = new ViewInsertProxy()
+  let index = new ViewInsertParent()
   index.create(db)
 
   // column exists
-  t.ok(introspect.views('hierarchy_insert_proxy').length, 'create')
+  t.ok(introspect.views('hierarchy_insert_parent').length, 'create')
 
   // drop index
   index.drop(db)
 
   // column does not exist
-  t.notOk(introspect.views('hierarchy_insert_proxy').length, 'drop')
+  t.notOk(introspect.views('hierarchy_insert_parent').length, 'drop')
 
   t.end()
 })

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "prune": "npm prune",
     "build": "docker build -t 'pelias/spatial' .",
     "test": "tap --disable-coverage --exclude='test/common.js'",
+    "test_one": "tap --disable-coverage $@",
     "coverage": "./bin/coverage",
     "env_check": "tap --disable-coverage test/environment.js",
     "start": "./bin/start",


### PR DESCRIPTION
This PR reworks how the `hierarchy` table is generated.

Previously we were using a recursive CTE method which allowed the entire hierarchy to be generated by only inserting the single immediate parent.

It turns out that this method is not able to represent the WOF hierarchy accurately as it's not a pure tree structure, there are many examples where the hierarchy is incorrect using this method.

The work in this PR removes a bunch of that magic and simply uses the hierarchy as described in the WOF data.

Worth noting the WOF hierarchy is also not perfect as I found links to deprecated records, links to `-1` ids etc. etc.