### PR TITLE
use 3 letter abbr for dependencies

### DIFF
--- a/import/source/whosonfirst/config/generic.js
+++ b/import/source/whosonfirst/config/generic.js
@@ -46,8 +46,8 @@ function getAbbreviation (properties) {
   const abbreviation = _.get(properties, 'wof:abbreviation')
   const country = _.get(properties, 'wof:country')
 
-  // use the 3 letter country code for 'country' placetypes
-  if (placeType === 'country' && countryCode) {
+  // use the 3 letter country code for 'country' and 'dependency' placetypes
+  if (['country', 'dependency'].includes(placeType) && countryCode) {
     return countryCode.trim()
   }
 


### PR DESCRIPTION
small change to the whosonfirst data mapper to ensure that 3-letter abbreviations are used for `dependency` placetypes as per what we are doing for `country`.

https://github.com/pelias/wof-admin-lookup/blob/30e0543251ec85c50e58b9fcecea80bbb78d5471/src/pip/components/extractFields.js#L73C7-L73C41