### PR TITLE
wof: ignore -1 values hierarchy ids, skip parentless neighbourhood records

### DIFF
--- a/import/source/whosonfirst/map/hierarchies.js
+++ b/import/source/whosonfirst/map/hierarchies.js
@@ -27,12 +27,15 @@ function mapper (place, properties) {
 
     let depth = 0
     for (const key in sorted) {
+      const parentId = sorted[key].toString()
+      if (parentId === '-1') { continue }
+
       place.addHierarchy(
         new Hierarchy(
           place.identity,
           new Identity(
             place.identity.source,
-            sorted[key].toString()
+            parentId
           ),
           `wof:${o}`,
           depth++

--- a/import/source/whosonfirst/map/hierarchies.test.js
+++ b/import/source/whosonfirst/map/hierarchies.test.js
@@ -89,6 +89,29 @@ tap.test('mapper: multiple hierarchies', (t) => {
 
   t.end()
 })
+tap.test('mapper: skip -1 ids', (t) => {
+  const p = new Place(fixture.region.identity, fixture.region.ontology)
+  map(p, {
+    'wof:hierarchy': [
+      {
+        continent_id: 102191581,
+        country_id: -1,
+        disputed_id: 1159339547,
+        empire_id: 874393555,
+        region_id: 85688855
+      }
+    ]
+  })
+
+  t.same([
+    new Hierarchy(p.identity, p.identity, 'wof:0', 0),
+    new Hierarchy(p.identity, new Identity('wof', '1159339547'), 'wof:0', 1),
+    new Hierarchy(p.identity, new Identity('wof', '874393555'), 'wof:0', 2),
+    new Hierarchy(p.identity, new Identity('wof', '102191581'), 'wof:0', 3)
+  ], p.hierarchy)
+
+  t.end()
+})
 tap.test('mapper: key ordering', (t) => {
   const p = new Place(new Identity('wof', '1729339019'), new Ontology('admin', 'locality'))
   map(p, {

--- a/import/source/whosonfirst/map/place.test.js
+++ b/import/source/whosonfirst/map/place.test.js
@@ -153,3 +153,48 @@ tap.test('altgeoms: skip alt geometries', t => {
   t.equal(place, null)
   t.end()
 })
+
+tap.test('mapper: filter neighbourhoods with empty hierarchy', t => {
+  let place = map({
+    id: 1,
+    properties: {
+      'wof:placetype': 'neighbourhood',
+      'wof:hierarchy': []
+    }
+  })
+  t.equal(place, null)
+  t.end()
+})
+
+tap.test('mapper: filter neighbourhoods with no locality or localadmin parent', t => {
+  let place = map({
+    id: 1,
+    properties: {
+      'wof:placetype': 'neighbourhood',
+      'wof:hierarchy': [{
+        'region_id': 1
+      }]
+    }
+  })
+  t.equal(place, null)
+  t.end()
+})
+
+tap.test('mapper: maps neighbourhoods with balid parentage', t => {
+  let place = map({
+    id: 1,
+    properties: {
+      'wof:placetype': 'neighbourhood',
+      'wof:hierarchy': [{
+        'region_id': 1,
+        'locality_id': 2
+      }]
+    }
+  })
+  t.ok(place instanceof Place)
+  t.equal(place.identity.source, 'wof')
+  t.equal(place.identity.id, '1')
+  t.equal(place.ontology.class, 'admin')
+  t.equal(place.ontology.type, 'neighbourhood')
+  t.end()
+})


### PR DESCRIPTION
this PR contains two changes to the `whosonfirst` source importer:

1. Ignore any `hierarchy` entries where the ID is `-1`, unfortunately this is fairly common
2. Adopt the `filterOutCitylessNeighbourhoods` and `filterOutHierarchylessNeighbourhoods` behaviour from `wof-admin-lookup` which skips about 20k `neighbourhood` records which don't have valid parentage.