### PR TITLE
fix order of arguments for StatementInsert

### DIFF
--- a/module/geometry/StatementInsert.js
+++ b/module/geometry/StatementInsert.js
@@ -11,8 +11,8 @@ class StatementInsert extends SqliteStatement {
           INSERT OR REPLACE INTO ${dbname}.geometry (
             source,
             id,
-            geom,
             role,
+            geom,
           ) VALUES (
             @source,
             @id,


### PR DESCRIPTION
I noticed that the order of arguments in this query are inconsistent and likely wrong.
The query is currently not being used which is why it wasn't noticed.