### PR TITLE
zcta: update for 2024 vintage

### DIFF
--- a/import/source/zcta/download.txt
+++ b/import/source/zcta/download.txt
@@ -1,1 +1,5 @@
 https://www.census.gov/cgi-bin/geo/shapefiles/index.php
+
+ogr2ogr tl_2024_us_zcta520.geojsonl /vsizip/tl_2024_us_zcta520.zip
+
+cat tl_2024_us_zcta520.geojsonl | node bin/spatial.js --db=zcta.spatial.db import zcta

--- a/import/source/zcta/map/geometries.js
+++ b/import/source/zcta/map/geometries.js
@@ -19,8 +19,8 @@ function mapper (place, doc) {
   if (!isPolygon) { return }
 
   // 'internal point'
-  let lon = parseFloat(_.get(properties, 'INTPTLON10'))
-  let lat = parseFloat(_.get(properties, 'INTPTLAT10'))
+  let lon = parseFloat(_.get(properties, 'INTPTLON20'))
+  let lat = parseFloat(_.get(properties, 'INTPTLAT20'))
   if (!isNaN(lat) && !isNaN(lon)) {
     place.addGeometry(new Geometry(
       wkx.Geometry.parse(`POINT(${lon} ${lat})`),

--- a/import/source/zcta/map/geometries.test.js
+++ b/import/source/zcta/map/geometries.test.js
@@ -88,8 +88,8 @@ tap.test('mapper: internal point', (t) => {
       ]
     },
     properties: {
-      'INTPTLON10': 1.1,
-      'INTPTLAT10': 2.2
+      'INTPTLON20': 1.1,
+      'INTPTLAT20': 2.2
     }
   })
   t.equal(p.geometry.length, 2)

--- a/import/source/zcta/map/names.js
+++ b/import/source/zcta/map/names.js
@@ -3,7 +3,7 @@ const Name = require('../../../../model/Name')
 
 function mapper (place, properties) {
   // generic name properties
-  place.addName(new Name('und', 'default', false, _.get(properties, 'ZCTA5CE10', '').trim()))
+  place.addName(new Name('und', 'default', false, _.get(properties, 'ZCTA5CE20', '').trim()))
 }
 
 module.exports = mapper

--- a/import/source/zcta/map/names.test.js
+++ b/import/source/zcta/map/names.test.js
@@ -12,7 +12,7 @@ tap.test('mapper: properties empty', (t) => {
 })
 tap.test('mapper: name', (t) => {
   let p = new Place()
-  map(p, { 'ZCTA5CE10': ' example1 ' })
+  map(p, { 'ZCTA5CE20': ' example1 ' })
 
   t.equal(p.name.length, 1)
   t.equal(p.name[0].lang, 'und')

--- a/import/source/zcta/map/place.js
+++ b/import/source/zcta/map/place.js
@@ -17,7 +17,7 @@ function mapper (doc) {
 
   // instantiate a new place
   const place = new Place(
-    new Identity('uscensus', 'zcta' + DELIM + _.get(properties, 'ZCTA5CE10', '').trim()),
+    new Identity('uscensus', 'zcta' + DELIM + _.get(properties, 'ZCTA5CE20', '').trim()),
     new Ontology('admin', 'postalcode')
   )
 

--- a/import/source/zcta/map/place.test.js
+++ b/import/source/zcta/map/place.test.js
@@ -11,7 +11,7 @@ tap.test('mapper: properties empty', (t) => {
 tap.test('mapper: maps identity & ontology', (t) => {
   let place = map({
     properties: {
-      'ZCTA5CE10': '90210'
+      'ZCTA5CE20': '90210'
     }
   })
   t.ok(place instanceof Place)
@@ -24,7 +24,7 @@ tap.test('mapper: maps identity & ontology', (t) => {
 tap.test('mapper: maps geometry', (t) => {
   let place = map({
     properties: {
-      'ZCTA5CE10': '90210'
+      'ZCTA5CE20': '90210'
     },
     geometry: require('../../../../test/fixture/geojson.triangle')
   })

--- a/import/source/zcta/map/properties.test.js
+++ b/import/source/zcta/map/properties.test.js
@@ -13,16 +13,16 @@ tap.test('mapper: properties empty', (t) => {
 tap.test('mapper: uscensus-specific properties', (t) => {
   let p = new Place()
   map(p, {
-    'CLASSFP10': 'B5',
-    'MTFCC10': 'G6350',
-    'INTPTLON10': 1.1,
-    'INTPTLAT10': 2.2
+    'CLASSFP20': 'B5',
+    'MTFCC20': 'G6350',
+    'INTPTLON20': 1.1,
+    'INTPTLAT20': 2.2
   })
 
   t.equal(p.property.length, 2)
-  t.equal(p.property[0].key, 'uscensus:CLASSFP10', 'CLASSFP10')
-  t.equal(p.property[0].value, 'B5', 'CLASSFP10')
-  t.equal(p.property[1].key, 'uscensus:MTFCC10', 'MTFCC10')
-  t.equal(p.property[1].value, 'G6350', 'MTFCC10')
+  t.equal(p.property[0].key, 'uscensus:CLASSFP20', 'CLASSFP20')
+  t.equal(p.property[0].value, 'B5', 'CLASSFP20')
+  t.equal(p.property[1].key, 'uscensus:MTFCC20', 'MTFCC20')
+  t.equal(p.property[1].value, 'G6350', 'MTFCC20')
   t.end()
 })


### PR DESCRIPTION
The ZCTA property names have changed, this PR updates them to work with the latest available download data from Us Census (at time of writing `tl_2024_us_zcta520.zip`).