### PR TITLE
demo: reduce polygon simplification values for demo slider

### DIFF
--- a/server/demo/views/pages/pip.hbs
+++ b/server/demo/views/pages/pip.hbs
@@ -14,7 +14,7 @@
       <p class="panel-heading">Simplification</p>
       <div class="simplification-box">
         <input id="simplification-info" disabled="disabled" />
-        <input id="simplification" class="slider is-fullwidth is-medium" step="1" min="0" max="100" value="50" type="range">
+        <input id="simplification" class="slider is-fullwidth is-medium" step="30" min="0" max="60" value="30" type="range">
       </div>
     </nav>
 


### PR DESCRIPTION
this PR reduces the granularity of the polygon simplification slider to only offer 3 options (ie. off/small/medium).

<img width="248" height="130" alt="Screenshot 2025-07-14 at 13 10 05" src="https://github.com/user-attachments/assets/563516c4-6912-404e-a115-7ac7f8dc2c69" />
