### PR TITLE
Support Node.js 24

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM ubuntu:noble
 # apt dependencies
 RUN apt-get update -y && \
   apt-get install -y curl && \
-  curl -fsSL https://deb.nodesource.com/setup_23.x -o nodesource_setup.sh && \
+  curl -fsSL https://deb.nodesource.com/setup_24.x -o nodesource_setup.sh && \
   bash nodesource_setup.sh && \
   apt-get install -y nodejs libsqlite3-mod-spatialite && \
   rm -rf /var/lib/apt/lists/*

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   "dependencies": {
     "@mapbox/polyline": "^1.1.1",
     "@turf/buffer": "^5.1.5",
-    "better-sqlite3": "^11.10.0",
+    "better-sqlite3": "^12.2.0",
     "bindings": "^1.5.0",
     "csv-parse": "^4.8.2",
     "express": "^4.17.1",


### PR DESCRIPTION
This updates `better-sqlite3` and the `Dockerfile` to support Node.js 24. The previously used version, Node.js 23, is now EOL.