### PR TITLE
add "empire" to `displayLayers` for pelias pip view

### DIFF
--- a/server/routes/pip_pelias.js
+++ b/server/routes/pip_pelias.js
@@ -10,7 +10,7 @@ const untrustedLayers = new Set(['neighbourhood'])
  */
 
 // layers supported in the GeoJSON output
-// note: some layers such as 'empire', 'disputed', 'venue' etc. are excluded
+// note: some layers such as 'disputed', 'venue' etc. are excluded
 const displayLayers = new Set([
   'neighbourhood',
   'borough',
@@ -23,6 +23,7 @@ const displayLayers = new Set([
   'macroregion',
   'dependency',
   'country',
+  'empire',
   'continent',
   'marinearea',
   'ocean'


### PR DESCRIPTION
this PR adds the 'empire' layer to the default layers returned by the reverse-compatible pelias pip view.

the `empire` admin placetype is rarely returned but could previously be explicitly targeted for reverse queries.