### PR TITLE
refactor "remap" to avoid use of `Function.prototype.bind()`

### DIFF
--- a/server/routes/pip_pelias.js
+++ b/server/routes/pip_pelias.js
@@ -45,7 +45,10 @@ module.exports = function (req, res) {
     searchLayers
   }
 
-  verbose.bind({ remap: remapFromHierarchy })(req, res)
+  // remap verbose view using custom formatter
+  req.remap = remapFromHierarchy
+
+  return verbose(req, res)
 }
 
 // rewite the verbose view to match the expected format

--- a/server/routes/pip_verbose.js
+++ b/server/routes/pip_verbose.js
@@ -73,8 +73,8 @@ module.exports = function (req, res) {
   })
 
   // allow other views to utilize this view
-  if (typeof this.remap === 'function') {
-    resp = this.remap(resp, req, res)
+  if (typeof req.remap === 'function') {
+    resp = req.remap(resp, req, res)
   }
 
   // send json


### PR DESCRIPTION
this PR is a simple refactor to avoid the use of `Function.prototype.bind()` and the corresponding reference to `this.remap`.