### PR TITLE
pip: add "summary" table to speed up PIP operations

### DIFF
--- a/bin/cmd/import.js
+++ b/bin/cmd/import.js
@@ -101,5 +101,6 @@ module.exports = {
     stream
       .pipe(service.createImportStream())
       .on('finish', ticker.stop.bind(ticker))
+      .on('finish', service.close.bind(service))
   }
 }

--- a/module/Module.js
+++ b/module/Module.js
@@ -46,6 +46,11 @@ class Module {
       }
     }
   }
+  close (config) {
+    [this.init, this.table, this.index, this.statement]
+      .map(p => Object.values(p).filter(m => typeof m.close === 'function'))
+      .flat().forEach(m => m.close(this.db, config))
+  }
 }
 
 module.exports = Module

--- a/module/pip/PointInPolygonModule.js
+++ b/module/pip/PointInPolygonModule.js
@@ -1,17 +1,19 @@
 const Module = require('../Module')
-const GeoViewPointInPolygon = require('../shard/GeoViewPointInPolygon')
 const StatementPointInPolygon = require('./StatementPointInPolygon')
 const StatementPointInPolygonVerbose = require('./StatementPointInPolygonVerbose')
+const StatementPointInPolygonSummary = require('./StatementPointInPolygonSummary')
+const TableSummary = require('./TableSummary')
 
 class PointInPolygonModule extends Module {
   constructor (db) {
     super(db)
+    this.table = {
+      summary: new TableSummary()
+    }
     this.statement = {
       pip: new StatementPointInPolygon(),
-      verbose: new StatementPointInPolygonVerbose()
-    }
-    this.view = {
-      pip: new GeoViewPointInPolygon()
+      verbose: new StatementPointInPolygonVerbose(),
+      summary: new StatementPointInPolygonSummary()
     }
   }
 }

--- a/module/pip/StatementPointInPolygonSummary.js
+++ b/module/pip/StatementPointInPolygonSummary.js
@@ -1,0 +1,86 @@
+const _ = require('lodash')
+const SqliteStatement = require('../../sqlite/SqliteStatement')
+
+/**
+ * Fuzzy distance allows PIP to return matches where the point is
+ * not contained completely within the target polygon but is within
+ * this threshold of the boundary.
+ *
+ * This is intended to assist in improved matching of points near
+ * marine boundaries and may also help to provide matching adjacent
+ * polygons to index as alternative parents for search.
+ *
+ * note: Interior matches are favoured as results are returned in
+ * distance order ascending.
+ *
+ * The default value 0.001 degrees corresponds to ~111.32m longitude
+ * at the equator, ~78.66m at 45°, ~55.66m at 60° and ~28.83m at 75°.
+ *
+ * This view uses the 'summary' table for performance.
+ */
+const fuzzyDistanceThreshold = 0.001
+
+class StatementPointInPolygonSummary extends SqliteStatement {
+  create (db, config) {
+    try {
+      let dbname = _.get(config, 'database', 'main')
+      this.statement = db.prepare(`
+        SELECT
+          summary.source,
+          summary.id,
+          summary.type,
+          summary.bounds,
+          summary.centroid,
+          summary.name,
+          summary.abbr,
+          CASE
+            WHEN @hierarchy != 1 THEN json_object()
+            ELSE (
+              SELECT json_group_object(parent_type, json(parent_obj))
+              FROM (
+                SELECT
+                  parent.type AS parent_type,
+                  json_object(
+                    'id', parent.id,
+                    'name', parent.name,
+                    'abbr', parent.abbr,
+                    'centroid', parent.centroid,
+                    'bounds', parent.bounds
+                  ) AS parent_obj
+                FROM main.hierarchy
+                INNER JOIN main.summary AS parent ON (
+                  hierarchy.parent_source = parent.source AND
+                  hierarchy.parent_id = parent.id
+                )
+                WHERE hierarchy.parent_id != hierarchy.child_id
+                AND hierarchy.branch = 'wof:0'
+                AND child_source = summary.source
+                AND child_id = summary.id
+              )
+            )
+          END AS hierarchy,
+        ST_Distance(pip.geom, MakePoint( @lon, @lat, 4326 )) as distance
+        FROM ${dbname}.point_in_polygon AS pip
+        LEFT JOIN ${dbname}.summary AS summary USING (source, id)
+        WHERE search_frame = MakePoint( @lon, @lat, 4326 )
+        AND distance <= ${fuzzyDistanceThreshold}
+        AND (
+          CASE
+            WHEN @sources = '' THEN 1
+            WHEN @sources like '%' || CHAR(30) || summary.source || CHAR(30) || '%' THEN 1
+            ELSE 0
+          END
+        )
+        AND summary.class = 'admin'
+        AND summary.id > 0 -- do not return planet or invalid placetypes
+        GROUP BY summary.source, summary.id
+        ORDER BY summary.type ASC, distance ASC
+        LIMIT @limit
+      `)
+    } catch (e) {
+      this.error('PREPARE STATEMENT', e)
+    }
+  }
+}
+
+module.exports = StatementPointInPolygonSummary

--- a/module/pip/StatementPointInPolygonVerbose.js
+++ b/module/pip/StatementPointInPolygonVerbose.js
@@ -18,7 +18,7 @@ const SqliteStatement = require('../../sqlite/SqliteStatement')
  */
 const fuzzyDistanceThreshold = 0.001
 
-class StatementPeliasView extends SqliteStatement {
+class StatementPeliasVerbose extends SqliteStatement {
   create (db, config) {
     try {
       let dbname = _.get(config, 'database', 'main')
@@ -181,4 +181,4 @@ class StatementPeliasView extends SqliteStatement {
   }
 }
 
-module.exports = StatementPeliasView
+module.exports = StatementPeliasVerbose

--- a/module/pip/TableSummary.js
+++ b/module/pip/TableSummary.js
@@ -1,0 +1,112 @@
+const _ = require('lodash')
+const SqliteTable = require('../../sqlite/SqliteTable')
+
+/**
+ * The summary table is used to oiptimize PIP queries
+ * by avoiding running the JOIN operations at query-time.
+ */
+
+class TableSummary extends SqliteTable {
+  create (db, config) {
+    try {
+      let dbname = _.get(config, 'database', 'main')
+      db.prepare(`
+        CREATE TABLE IF NOT EXISTS ${dbname}.summary (
+          source TEXT NOT NULL,
+          id TEXT NOT NULL,
+          class TEXT NOT NULL,
+          type TEXT NOT NULL,
+          name TEXT NOT NULL,
+          abbr TEXT,
+          centroid TEXT NOT NULL,
+          bounds TEXT NOT NULL,
+          PRIMARY KEY (source, id)
+        )
+      `).run()
+    } catch (e) {
+      this.error('CREATE TABLE', e)
+    }
+  }
+  drop (db, config) {
+    try {
+      let dbname = _.get(config, 'database', 'main')
+      db.prepare(`
+        DROP TABLE IF EXISTS ${dbname}.summary
+      `).run()
+    } catch (e) {
+      this.error('DROP TABLE', e)
+    }
+  }
+  merge (db, fromDbName, toDbName) {
+    try {
+      db.prepare(`
+        INSERT OR REPLACE INTO ${toDbName}.summary
+        SELECT * FROM ${fromDbName}.summary
+      `).run()
+    } catch (e) {
+      this.error('MERGE TABLE', e)
+    }
+  }
+  close (db, config) {
+    if (config && config.readonly === true) { return }
+    try {
+      let dbname = _.get(config, 'database', 'main')
+      db.prepare(`DELETE FROM ${dbname}.summary`).run()
+      db.prepare(`
+        INSERT INTO ${dbname}.summary
+        SELECT
+          source,
+          id,
+          class,
+          type,
+          (
+            SELECT name
+            FROM ${dbname}.name
+            WHERE source = place.source
+            AND id = place.id
+            AND lang = 'und'
+            AND tag = 'default'
+            AND abbr = 0
+            LIMIT 1
+          ) AS name,
+          (
+            SELECT name
+            FROM ${dbname}.name
+            WHERE source = place.source
+            AND id = place.id
+            AND lang = 'und'
+            AND tag = 'default'
+            AND abbr = 1
+            LIMIT 1
+          ) AS abbr,
+          (
+            SELECT X( geom ) || ',' || Y( geom )
+            FROM ${dbname}.geometry
+            WHERE source = place.source
+            AND id = place.id
+            AND role = 'centroid'
+            AND geom != ''
+            LIMIT 1
+          ) AS centroid,
+          (
+            SELECT
+              MbrMinX( geom ) || ',' || MbrMinY( geom ) || ',' ||
+              MbrMaxX( geom ) || ',' || MbrMaxY( geom )
+            FROM ${dbname}.geometry
+            WHERE source = place.source
+            AND id = place.id
+            AND role = 'envelope'
+            AND geom != ''
+            LIMIT 1
+          ) AS bounds
+        FROM place
+        WHERE centroid IS NOT NULL
+        AND bounds IS NOT NULL
+      `).run()
+    } catch (e) {
+      this.error('POPULATE TABLE', e)
+    }
+  }
+}
+
+module.exports = TableSummary

--- a/module/pip/TableSummary.test.js
+++ b/module/pip/TableSummary.test.js
@@ -1,0 +1,283 @@
+const tap = require('tap')
+const format = require('../../import/format')
+const common = require('../../test/common')
+const SqliteIntrospect = require('../../sqlite/SqliteIntrospect')
+const PointInPolygonModule = require('./PointInPolygonModule')
+const GeometryModule = require('../geometry/GeometryModule')
+const PlaceModule = require('../place/PlaceModule')
+const NameModule = require('../name/NameModule')
+const ShardModule = require('../shard/ShardModule')
+const HierarchyModule = require('../hierarchy/HierarchyModule')
+
+const installDependencies = (db) => {
+  new NameModule(db).setup()
+  new PlaceModule(db).setup()
+  new HierarchyModule(db).setup()
+  new GeometryModule(db).setup()
+  new ShardModule(db).setup()
+}
+
+tap.test('create & drop', (t) => {
+  let db = common.tempSpatialDatabase()
+  let introspect = new SqliteIntrospect(db)
+
+  installDependencies(db)
+
+  // table does not exist
+  t.notOk(introspect.tables().includes('summary'), 'prior state')
+
+  // setup module
+  let pip = new PointInPolygonModule(db)
+  pip.setup()
+
+  // table exists
+  t.ok(introspect.tables().includes('summary'), 'create')
+
+  // drop table
+  pip.table.summary.drop(db)
+
+  // table does not exist
+  t.notOk(introspect.tables().includes('summary'), 'drop')
+
+  t.end()
+})
+
+tap.test('merge', (t) => {
+  let external = common.tempSpatialDatabase({ memory: false })
+  installDependencies(external)
+
+  // set up pip module
+  let pip = new PointInPolygonModule(external)
+  pip.setup()
+
+  // ensure table is empty
+  t.equal(external.prepare(`SELECT * FROM summary`).all().length, 0, 'prior state')
+
+  // insert some data
+  let stmt = external.prepare(`
+    INSERT INTO summary (source, id, class, type, name, abbr, centroid, bounds)
+    VALUES (@source, @id, @class, @type, @name, @abbr, @centroid, @bounds)
+  `)
+
+  stmt.run({
+    source: 'example',
+    id: 'id1',
+    class: 'admin',
+    type: 'test',
+    name: 'name1',
+    abbr: 'abbr1',
+    centroid: 'centroid1',
+    bounds: 'bounds1'
+  })
+  stmt.run({
+    source: 'example',
+    id: 'id2',
+    class: 'admin',
+    type: 'test',
+    name: 'name2',
+    abbr: 'abbr2',
+    centroid: 'centroid2',
+    bounds: 'bounds2'
+  })
+  stmt.run({
+    source: 'example',
+    id: 'id3',
+    class: 'admin',
+    type: 'test',
+    name: 'name1',
+    abbr: null,
+    centroid: 'centroid3',
+    bounds: 'bounds3'
+  })
+
+  // ensure table is populated
+  t.equal(external.prepare(`SELECT * FROM summary`).all().length, 3, 'write')
+
+  // close external database
+  external.close()
+
+  // ---
+
+  // generate second database
+  let db = common.tempSpatialDatabase()
+  installDependencies(db)
+
+  // setup module on second db
+  let mod = new PointInPolygonModule(db)
+  mod.setup()
+
+  // attach external database
+  db.prepare(`ATTACH DATABASE '${external.name}' as 'external'`).run()
+
+  // ensure external table is populated
+  t.equal(db.prepare(`SELECT * FROM external.summary`).all().length, 3, 'external state')
+
+  // table does not exist
+  mod.table.summary.merge(db, 'external', 'main')
+
+  // ensure table is merged to main db
+  t.equal(db.prepare(`SELECT * FROM summary`).all().length, 3, 'merged')
+
+  t.end()
+})
+
+tap.test('definition', (t) => {
+  let db = common.tempSpatialDatabase()
+  installDependencies(db)
+
+  let introspect = new SqliteIntrospect(db)
+
+  // setup module
+  let mod = new PointInPolygonModule(db)
+  mod.setup()
+
+  // test columns
+  let columns = introspect.columns('summary')
+
+  // source
+  t.same(columns[0], {
+    cid: 0,
+    name: 'source',
+    type: 'TEXT',
+    notnull: 1,
+    dflt_value: null,
+    pk: 1
+  }, 'source')
+
+  // id
+  t.same(columns[1], {
+    cid: 1,
+    name: 'id',
+    type: 'TEXT',
+    notnull: 1,
+    dflt_value: null,
+    pk: 2
+  }, 'id')
+
+  // class
+  t.same(columns[2], {
+    cid: 2,
+    name: 'class',
+    type: 'TEXT',
+    notnull: 1,
+    dflt_value: null,
+    pk: 0
+  }, 'class')
+
+  // type
+  t.same(columns[3], {
+    cid: 3,
+    name: 'type',
+    type: 'TEXT',
+    notnull: 1,
+    dflt_value: null,
+    pk: 0
+  }, 'type')
+
+  // name
+  t.same(columns[4], {
+    cid: 4,
+    name: 'name',
+    type: 'TEXT',
+    notnull: 1,
+    dflt_value: null,
+    pk: 0
+  }, 'name')
+
+  // abbr
+  t.same(columns[5], {
+    cid: 5,
+    name: 'abbr',
+    type: 'TEXT',
+    notnull: 0,
+    dflt_value: null,
+    pk: 0
+  }, 'abbr')
+
+  // centroid
+  t.same(columns[6], {
+    cid: 6,
+    name: 'centroid',
+    type: 'TEXT',
+    notnull: 1,
+    dflt_value: null,
+    pk: 0
+  }, 'centroid')
+
+  // bounds
+  t.same(columns[7], {
+    cid: 7,
+    name: 'bounds',
+    type: 'TEXT',
+    notnull: 1,
+    dflt_value: null,
+    pk: 0
+  }, 'bounds')
+
+  t.end()
+})
+
+tap.test('populate', (t) => {
+  let db = common.tempSpatialDatabase()
+
+  let name = new NameModule(db)
+  name.setup()
+
+  let place = new PlaceModule(db)
+  place.setup()
+
+  let hierarchy = new HierarchyModule(db)
+  hierarchy.setup()
+
+  let geometry = new GeometryModule(db)
+  geometry.setup()
+
+  let shard = new ShardModule(db)
+  shard.setup()
+
+  // setup module
+  let pip = new PointInPolygonModule(db)
+  pip.setup()
+
+  // nothing in dependent tables
+
+  // run the close method and check for values in the summary table
+  pip.table.summary.close(db, {})
+  t.same(db.prepare(`SELECT * FROM summary`).all(), [])
+
+  // insert values in dependent tables
+  const identity = { source: 'example', id: '1' }
+
+  // insert into place
+  place.statement.insert.run({ ...identity, class: 'aclass', type: 'atype' })
+  t.equal(db.prepare(`SELECT * FROM place`).all().length, 1)
+
+  // insert into name
+  name.statement.insert.run({ ...identity, lang: 'und', tag: 'default', abbr: 0, name: 'aname' })
+  name.statement.insert.run({ ...identity, lang: 'und', tag: 'default', abbr: 1, name: 'anabbr' })
+  t.equal(db.prepare(`SELECT * FROM name`).all().length, 2)
+
+  // insert into geometry
+  const centroid = format.from('point', 'geojson', { coordinates: [1, 1] })
+  const envelope = format.from('polygon', 'geojson', {
+    coordinates: [[[1, 1], [2, 1], [2, 2], [1, 2], [1, 1]]]
+  })
+  geometry.statement.insert.run({ ...identity, role: 'centroid', geom: centroid.toWkb() })
+  geometry.statement.insert.run({ ...identity, role: 'envelope', geom: envelope.toWkb() })
+  t.equal(db.prepare(`SELECT * FROM geometry`).all().length, 2)
+
+  // run the close method and check for values in the summary table
+  pip.table.summary.close(db, {})
+  t.same(db.prepare(`SELECT * FROM summary`).all(), [{
+    source: 'example',
+    id: '1',
+    class: 'aclass',
+    type: 'atype',
+    name: 'aname',
+    abbr: 'anabbr',
+    centroid: '1.0,1.0',
+    bounds: '1.0,1.0,2.0,2.0'
+  }])
+
+  t.end()
+})

--- a/module/place/TablePlace.js
+++ b/module/place/TablePlace.js
@@ -1,7 +1,7 @@
 const _ = require('lodash')
 const SqliteTable = require('../../sqlite/SqliteTable')
 
-class TableDocument extends SqliteTable {
+class TablePlace extends SqliteTable {
   create (db, config) {
     try {
       let dbname = _.get(config, 'database', 'main')
@@ -39,4 +39,4 @@ class TableDocument extends SqliteTable {
   }
 }
 
-module.exports = TableDocument
+module.exports = TablePlace

--- a/service/ImportService.js
+++ b/service/ImportService.js
@@ -95,6 +95,11 @@ class ImportService {
       next()
     }, options)
   }
+  close () {
+    for (let name in this.module) {
+      this.module[name].close(this.config)
+    }
+  }
 }
 
 module.exports = ImportService

--- a/service/QueryService.js
+++ b/service/QueryService.js
@@ -50,6 +50,11 @@ class QueryService {
       this.module[name].setup(this.config)
     }
   }
+  close () {
+    for (let name in this.module) {
+      this.module[name].close(this.config)
+    }
+  }
 }
 
 module.exports = QueryService


### PR DESCRIPTION
this PR adds a new "summary" table which can be used to avoid the `JOIN` operations when performing a point-in-polygon query, resulting in a ~50% reduction in latency ~`1.275ms -> 0.524ms`

this PR is essentially a no-op at this stage, as I'd like to regenerate the databases on the CDN before merging code which utilises the new table. 

the `summary` table follows a new workflow, where it is generated after all the other data is imported, but before the database is closed, as such it required a little new 'plumbing'.