### PR TITLE
feat(geom,shard): ensure default simplify tolerance of `0.0001`

### DIFF
--- a/bin/cmd/import.js
+++ b/bin/cmd/import.js
@@ -45,7 +45,7 @@ module.exports = {
     // tweaks
     yargs.option('tweak_module_geometry_simplify', {
       type: 'number',
-      default: 0.0,
+      default: 0.0001,
       coerce: parseFloat,
       describe: 'simplification tolerance for geometry module'
     })
@@ -81,12 +81,12 @@ module.exports = {
       verbose: argv.verbose,
       module: {
         geometry: {
-          simplify: argv.tweak_module_geometry_simplify || undefined
+          simplify: argv.tweak_module_geometry_simplify
         },
         shard: {
-          simplify: argv.tweak_module_shard_simplify || undefined,
-          complexity: argv.tweak_module_shard_complexity || undefined,
-          depth: argv.tweak_module_shard_depth || undefined
+          simplify: argv.tweak_module_shard_simplify,
+          complexity: argv.tweak_module_shard_complexity,
+          depth: argv.tweak_module_shard_depth
         }
       }
     })

--- a/module/geometry/StatementInsert.js
+++ b/module/geometry/StatementInsert.js
@@ -12,7 +12,7 @@ class StatementInsert extends SqliteStatement {
             source,
             id,
             role,
-            geom,
+            geom
           ) VALUES (
             @source,
             @id,

--- a/module/shard/TriggerGeometryInsert.js
+++ b/module/shard/TriggerGeometryInsert.js
@@ -6,6 +6,7 @@ class TriggerGeometryInsert extends SqliteStatement {
     try {
       let dbname = _.get(config, 'database', 'main')
       let complexity = _.clamp(_.get(config, 'module.shard.complexity', 200), 5, 1000000)
+      let simplify = _.get(config, 'module.shard.simplify', 0.0001)
       db.prepare(`
         CREATE TRIGGER IF NOT EXISTS shard_geometry_insert
         AFTER INSERT ON ${dbname}.geometry
@@ -21,7 +22,7 @@ class TriggerGeometryInsert extends SqliteStatement {
 
           -- insert collection into tmp table
           INSERT INTO shard_subdivide (geom)
-          SELECT ST_Subdivide(NEW.geom, ${complexity})
+          SELECT ST_Subdivide(ST_SimplifyPreserveTopology(NEW.geom, ${simplify}), ${complexity})
           WHERE NEW.geom IS NOT NULL;
 
           -- insert shards in to shard table

--- a/module/shard/TriggerGeometryInsert.test.js
+++ b/module/shard/TriggerGeometryInsert.test.js
@@ -81,7 +81,7 @@ tap.test('definition', (t) => {
 
           -- insert collection into tmp table
           INSERT INTO shard_subdivide (geom)
-          SELECT ST_Subdivide(NEW.geom, 200)
+          SELECT ST_Subdivide(ST_SimplifyPreserveTopology(NEW.geom, 0.0001), 200)
           WHERE NEW.geom IS NOT NULL;
 
           -- insert shards in to shard table


### PR DESCRIPTION
this PR sets the default Douglas-Peuker simplification tolerance for both `geometry` and `shard` tables to `0.0001`

in practice this value is so small it is visually indistinguishable, but has the benefit of **reducing the database size by up to 75%** 😱 

see: https://www.seabre.com/simplify-geometry/

cc/ @Joxit I think this may be preferable to updating the shard *complexity*, or maybe we do both 🤔 