### PR TITLE
pip: disable summary statement

### DIFF
--- a/module/pip/PointInPolygonModule.js
+++ b/module/pip/PointInPolygonModule.js
@@ -1,7 +1,7 @@
 const Module = require('../Module')
 const StatementPointInPolygon = require('./StatementPointInPolygon')
 const StatementPointInPolygonVerbose = require('./StatementPointInPolygonVerbose')
-const StatementPointInPolygonSummary = require('./StatementPointInPolygonSummary')
+// const StatementPointInPolygonSummary = require('./StatementPointInPolygonSummary')
 const TableSummary = require('./TableSummary')
 
 class PointInPolygonModule extends Module {
@@ -12,8 +12,8 @@ class PointInPolygonModule extends Module {
     }
     this.statement = {
       pip: new StatementPointInPolygon(),
-      verbose: new StatementPointInPolygonVerbose(),
-      summary: new StatementPointInPolygonSummary()
+      verbose: new StatementPointInPolygonVerbose()
+      // summary: new StatementPointInPolygonSummary()
     }
   }
 }


### PR DESCRIPTION
this PR fixes a mistake where the new [summary](https://github.com/pelias/spatial/pull/114) table was also creating a prepared statement.

as an effect, this would cause a fatal error on startup for any users using the latest docker image with an older database version (as mentioned in https://github.com/pelias/spatial/pull/117).

the error is:
```bash
error: PREPARE STATEMENT
SqliteError: no such table: main.summary
```

this PR disabled the prepared statement (for now) and will re-enable it in https://github.com/pelias/spatial/pull/117