### PR TITLE
demo: set default simplification to 0

### DIFF
--- a/server/demo/views/pages/pip.hbs
+++ b/server/demo/views/pages/pip.hbs
@@ -14,7 +14,7 @@
       <p class="panel-heading">Simplification</p>
       <div class="simplification-box">
         <input id="simplification-info" disabled="disabled" />
-        <input id="simplification" class="slider is-fullwidth is-medium" step="30" min="0" max="60" value="30" type="range">
+        <input id="simplification" class="slider is-fullwidth is-medium" step="30" min="0" max="60" value="0" type="range">
       </div>
     </nav>
 


### PR DESCRIPTION
this minor PR sets the default simplify threshold in the web demo to `0.0`.

since the recent PRs to simplify geometries on ingestion this is less necessary, setting it to 0.0 avoids using additional CPU to perform the simplification at runtime.

the slider remains, it's just defaulted to the left position now.

<img width="280" height="125" alt="Screenshot 2025-09-12 at 11 32 04" src="https://github.com/user-attachments/assets/ddc53574-5a45-49a7-9e59-da13e1837991" />
