### PR TITLE
read `QueryService` filename from `pelias/config`

### DIFF
--- a/bin/cmd/server.js
+++ b/bin/cmd/server.js
@@ -8,12 +8,11 @@ module.exports = {
     // optional params
     yargs.option('db', {
       type: 'string',
-      default: 'geo.db',
       describe: 'location of spatial database file'
     })
   },
   handler: (argv) => {
     const script = path.resolve(__dirname, '../../server/http.js')
-    spawn('node', [script, argv.db], { stdio: 'inherit' })
+    spawn('node', [script, ...argv.db ? [argv.db] : []], { stdio: 'inherit' })
   }
 }

--- a/config/ServiceConfiguration.js
+++ b/config/ServiceConfiguration.js
@@ -1,4 +1,6 @@
 const _ = require('lodash')
+const path = require('path')
+const peliasConfig = require('pelias-config')
 const PragmaStatement = require('./PragmaStatement')
 
 class ServiceConfiguration {
@@ -22,6 +24,17 @@ class ServiceConfiguration {
       new PragmaStatement('cache_size', ['2000']),
       new PragmaStatement('recursive_triggers', ['ON', 'OFF'])
     ])
+
+    // optionally read database filename from pelias/config (when available)
+    // note: you must set `config.pelias=true` to enable this functionality as
+    // it is undesirable at index generation time (for instance).
+    // note: existing `config.filename` value takes precedence over pelias config
+    if (!_.has(config, 'filename') && _.get(config, 'pelias') === true) {
+      const config = peliasConfig.generate().get('services.spatial')
+      if (config && !_.isEmpty(config.datapath) && !_.isEmpty(config.files)) {
+        this.filename = path.resolve(config.datapath, _.first(_.castArray(config.files)))
+      }
+    }
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "locale": "^0.1.0",
     "lodash": "^4.17.15",
     "morgan": "^1.9.1",
+    "pelias-config": "^6.0.0",
     "pelias-logger": "^1.4.1",
     "split2": "^3.1.1",
     "through2": "^3.0.1",

--- a/server/http.js
+++ b/server/http.js
@@ -25,7 +25,7 @@ const handlebars = require('express-handlebars')
 const helpers = require('handlebars-helpers')()
 const QueryService = require('../service/QueryService')
 const logger = require('pelias-logger').get('geometry')
-const dbFilename = process.argv[2] || 'geo.db'
+const filename = process.argv[2]
 
 // select the amount of cpus we will use
 const envCpus = parseInt(process.env.CPUS, 10)
@@ -68,10 +68,11 @@ app.engine('.hbs', handlebars({
 app.set('view engine', '.hbs')
 
 // init service
-logger.info(`load: ${dbFilename}`)
+logger.info(`load: ${filename}`)
 const service = new QueryService({
   readonly: true,
-  filename: dbFilename
+  pelias: true,
+  filename
 })
 
 // store $service on app

--- a/service/QueryService.js
+++ b/service/QueryService.js
@@ -1,3 +1,4 @@
+const fs = require('fs')
 const Database = require('better-sqlite3')
 const ServiceConfiguration = require('../config/ServiceConfiguration')
 const SpatialiteModule = require('../module/spatialite/SpatialiteModule')
@@ -19,6 +20,13 @@ class QueryService {
     let dbconf = { fileMustExist: true }
     if (this.config.readonly === true) { dbconf.readonly = true }
     if (this.config.verbose === true) { dbconf.verbose = console.error }
+
+    // ensure database file exists
+    if (!fs.existsSync(this.config.filename)) {
+      console.error(`database file not found: ${this.config.filename}`)
+      process.exit(1)
+    }
+
     this.db = new Database(this.config.filename, dbconf)
 
     // set up modules


### PR DESCRIPTION
this PR includes functionality for reading configuration from `pelias/config`.

when an object is defined in `pelias.json` at the path `services.spatial`, the properties `datapath` and `files` are used to determine the location of the database file to use for the `QueryService` (which is also the case for the http server).

note: that the option `pelias: true` must be passed when creating the `QueryService`, the default is not to use the config, as it wouldn't make sense for the `ImportService` since it would likely clobber downloads.

note: explicitly specifying a `filename` value takes precedence over pelias config