### PR TITLE
publish npm module

### DIFF
--- a/.github/workflows/_test.yml
+++ b/.github/workflows/_test.yml
@@ -7,7 +7,7 @@ jobs:
       matrix:
         os:
           - ubuntu-24.04
-        node-version: [ 18.x, 20.x, 22.x ]
+        node-version: [ 18.x, 20.x, 22.x, 24.x ]
     steps:
       - uses: actions/checkout@v4
       - name: 'Install node.js ${{ matrix.node-version }}'

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -3,9 +3,30 @@ on: push
 jobs:
   unit-tests:
     uses: ./.github/workflows/_test.yml
+  npm-publish:
+    needs: unit-tests
+    if: github.ref == 'refs/heads/master' && needs.unit-tests.result == 'success'
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22.x
+      - name: Run semantic-release
+        env:
+          GH_TOKEN: ${{ secrets.GH_SEMANTIC_RELEASE_TOKEN }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: >
+          if [[ -n "$GH_TOKEN" && -n "$NPM_TOKEN" ]]; then
+            curl "https://raw.githubusercontent.com/pelias/ci-tools/master/semantic-release.sh" | bash -
+          fi
   build-docker-images:
-    needs: [unit-tests]
-    runs-on: ubuntu-latest
+    # run this job if the unit tests passed and the npm-publish job was a success or was skipped
+    # note: github actions won't run a job if you don't call one of the status check functions, so `always()` is called since it evalutes to `true`
+    if: ${{ always() && needs.unit-tests.result == 'success' && (needs.npm-publish.result == 'success' || needs.npm-publish.result == 'skipped') }}
+    needs: [unit-tests, npm-publish]
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
       - name: Build Docker images

--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,9 @@
+.nyc_output
+.tap
+coverage
+test
+Dockerfile
+.dockerignore
+.git
+.gitignore
+*.db

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "pelias-spatial",
   "version": "0.0.0-development",
   "author": "pelias",
-  "description": "Pelias Geometry Service",
+  "description": "Pelias Spatial Service",
   "homepage": "https://github.com/pelias/spatial",
   "license": "MIT",
   "main": "index.js",
@@ -30,7 +30,7 @@
     "url": "https://github.com/pelias/spatial/issues"
   },
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=19.4.0"
   },
   "dependencies": {
     "@mapbox/polyline": "^1.1.1",


### PR DESCRIPTION
this PR configures this repo to be published as an `npm` module using `semantic-release` as per our other modules.

this allows us to import code into other modules, notably `wof-admin-lookup`.