### PR TITLE
fix for detecting `pelias/config` filename when using the CLI

### DIFF
--- a/config/ServiceConfiguration.js
+++ b/config/ServiceConfiguration.js
@@ -29,7 +29,7 @@ class ServiceConfiguration {
     // note: you must set `config.pelias=true` to enable this functionality as
     // it is undesirable at index generation time (for instance).
     // note: existing `config.filename` value takes precedence over pelias config
-    if (!_.has(config, 'filename') && _.get(config, 'pelias') === true) {
+    if (!_.get(config, 'filename') && _.get(config, 'pelias') === true) {
       const config = peliasConfig.generate().get('services.spatial')
       if (config && !_.isEmpty(config.datapath) && !_.isEmpty(config.files)) {
         this.filename = path.resolve(config.datapath, _.first(_.castArray(config.files)))

--- a/server/http.js
+++ b/server/http.js
@@ -24,7 +24,7 @@ const through = require('through2')
 const handlebars = require('express-handlebars')
 const helpers = require('handlebars-helpers')()
 const QueryService = require('../service/QueryService')
-const logger = require('pelias-logger').get('geometry')
+const logger = require('pelias-logger').get('spatial')
 const filename = process.argv[2]
 
 // select the amount of cpus we will use
@@ -68,12 +68,12 @@ app.engine('.hbs', handlebars({
 app.set('view engine', '.hbs')
 
 // init service
-logger.info(`load: ${filename}`)
 const service = new QueryService({
   readonly: true,
   pelias: true,
   filename
 })
+logger.info(`load: ${service.config.filename}`)
 
 // store $service on app
 app.locals.service = service


### PR DESCRIPTION
this PR fixes a subtle bug where `_.has()` returns true even if the value is `undefined`.