### PR TITLE
docker: use pelias baseimage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,4 @@
-FROM ubuntu:noble
-
-# apt dependencies
-RUN apt-get update -y && \
-  apt-get install -y curl && \
-  curl -fsSL https://deb.nodesource.com/setup_24.x -o nodesource_setup.sh && \
-  bash nodesource_setup.sh && \
-  apt-get install -y nodejs libsqlite3-mod-spatialite && \
-  rm -rf /var/lib/apt/lists/*
+FROM pelias/baseimage
 
 # working directory
 WORKDIR /code
@@ -14,11 +6,11 @@ WORKDIR /code
 # copy source files
 COPY . /code
 
-# install npm dependencies
-RUN npm i
-
-# run tests
-RUN npm t
+# install npm dependencies, run tests and prune dev dependencies
+RUN npm install && \
+  npm run env_check && \
+  npm test && \
+  npm prune --production
 
 # entrypoint
 ENTRYPOINT ["node", "bin/spatial.js"]

--- a/package.json
+++ b/package.json
@@ -54,8 +54,6 @@
     "yargs": "^13.3.0"
   },
   "devDependencies": {
-    "difflet": "^1.0.1",
-    "glob": "^7.1.6",
     "mitata": "^1.0.34",
     "node-mocks-http": "^1.17.2",
     "precommit-hook": "^3.0.0",


### PR DESCRIPTION
this PR uses the standard Pelias docker baseimage, which is now based on `noble`.

I've additionally removed some unused dev dependencies.