### PR TITLE
update geometry API endpoint to pass role as param instead of via query

### DIFF
--- a/server/routes/geometry.js
+++ b/server/routes/geometry.js
@@ -47,7 +47,7 @@ module.exports.one = function (req, res) {
   let query = {
     source: util.flatten(req.params.source),
     id: util.flatten(req.params.id),
-    role: util.flatten(req.query.role),
+    role: util.flatten(req.params.role),
     simplify: parseFloat(util.flatten(req.query.simplify)),
     limit: 100
   }


### PR DESCRIPTION
the HTTP API expected the 'role' to be a param rather than a query-string var.
eg. `/place/:source/:id/geometry/:role` should be `/place/foo/1/geometry/boundary` rather than `/place/foo/1/geometry?role=boundary`