### PR TITLE
Match record validity logic to placeholder

### DIFF
--- a/import/source/whosonfirst/map/place.js
+++ b/import/source/whosonfirst/map/place.js
@@ -42,11 +42,23 @@ function mapper (doc) {
   return place
 }
 
+// note: these semantics intentionally match placeholder's isValidWofRecord()
+// so that both services agree on which records exist, see:
+// https://github.com/pelias/placeholder/blob/master/prototype/wof.js
 function _isValid (properties) {
-  let isCurrent = _.get(properties, 'mz:is_current') !== 0
-  let isDeprecated = !!_.trim(properties['edtf:deprecated'] || '').length
-  let isSuperseded = _.isArray(_.get(properties, 'wof:superseded_by')) &&
+  // non-current records; the value may be a number or a string.
+  // -1 signifies an indeterminate state and is considered current
+  const current = _.get(properties, 'mz:is_current')
+  const isCurrent = !(current === 0 || current === '0')
+
+  // deprecated records; the value 'uuuu' signifies an unknown
+  // date and is not considered a deprecation
+  const deprecated = _.trim(properties['edtf:deprecated'] || '')
+  const isDeprecated = !!deprecated.length && deprecated !== 'uuuu'
+
+  const isSuperseded = _.isArray(_.get(properties, 'wof:superseded_by')) &&
     properties['wof:superseded_by'].length > 0
+
   return isCurrent && !isDeprecated && !isSuperseded
 }
 

--- a/import/source/whosonfirst/map/place.test.js
+++ b/import/source/whosonfirst/map/place.test.js
@@ -100,6 +100,32 @@ tap.test('invalid: current false', t => {
   t.end()
 })
 
+tap.test('invalid: current false as string', t => {
+  let place = map({
+    id: 1,
+    properties: {
+      'wof:placetype': 'locality',
+      'wof:name': 'Example',
+      'mz:is_current': '0'
+    }
+  })
+  t.equal(place, null)
+  t.end()
+})
+
+tap.test('invalid: current indeterminate', t => {
+  let place = map({
+    id: 1,
+    properties: {
+      'wof:placetype': 'locality',
+      'wof:name': 'Example',
+      'mz:is_current': -1
+    }
+  })
+  t.ok(place instanceof Place)
+  t.end()
+})
+
 tap.test('invalid: deprecated false', t => {
   let place = map({
     id: 1,
@@ -107,6 +133,19 @@ tap.test('invalid: deprecated false', t => {
       'wof:placetype': 'locality',
       'wof:name': 'Example',
       'edtf:deprecated': ''
+    }
+  })
+  t.ok(place instanceof Place)
+  t.end()
+})
+
+tap.test('invalid: deprecated uuuu is not a deprecation', t => {
+  let place = map({
+    id: 1,
+    properties: {
+      'wof:placetype': 'locality',
+      'wof:name': 'Example',
+      'edtf:deprecated': 'uuuu'
     }
   })
   t.ok(place instanceof Place)


### PR DESCRIPTION
Match placeholder's isValidWofRecord() semantics so both services agree on which WOF records exist:

- treat a string '0' value of mz:is_current as non-current (previously only the number 0 was recognized, allowing stringified values through)
- treat edtf:deprecated = 'uuuu' (unknown date) as not deprecated (previously any non-empty value was considered a deprecation)

Disagreement between the two services results in admin hierarchies referencing records Placeholder cannot resolve, which breaks parent name resolution when translating between languages.

In the future this would be a nice bit of common logic to extract somewhere, like to the `whosonfirst` repo.