### PR TITLE
Use `postalcode` layer instead of `postal_code` for OSM records

### DIFF
--- a/import/source/osmium/map/place.js
+++ b/import/source/osmium/map/place.js
@@ -11,6 +11,15 @@ const map = {
   geometries: require('./geometries')
 }
 
+// OSM tag values which name the same concept as a Who's on First placetype but
+// spell it differently. Normalizing here means downstream consumers only need
+// to know the WOF vocabulary; without this, `boundary=postal_code` records are
+// filtered out of the /query/pip/_view/pelias view, whose layer whitelist uses
+// the WOF spelling 'postalcode'.
+const ONTOLOGY_TYPE_ALIASES = {
+  postal_code: 'postalcode'
+}
+
 function mapper (doc) {
   // get document properties
   const properties = _.get(doc, 'properties')
@@ -32,6 +41,11 @@ function mapper (doc) {
       const boundary = scalar(_.get(properties, 'boundary', 'unknown').trim().toLowerCase())
       if (boundary !== 'multipolygon') { place.ontology.setType(boundary) }
     }
+  }
+
+  // normalize OSM spellings to their Who's on First equivalents
+  if (_.has(ONTOLOGY_TYPE_ALIASES, place.ontology.type)) {
+    place.ontology.setType(ONTOLOGY_TYPE_ALIASES[place.ontology.type])
   }
 
   // run mappers

--- a/import/source/osmium/map/place.test.js
+++ b/import/source/osmium/map/place.test.js
@@ -142,6 +142,54 @@ tap.test('mapper: derive ontology type from "boundary" tag - multivalue', (t) =>
   t.equal(place.ontology.type, 'example_boundary_tag')
   t.end()
 })
+tap.test('mapper: normalize "postal_code" boundary to the WOF placetype', (t) => {
+  let place = map({
+    properties: {
+      '@type': 'relation',
+      '@id': '100',
+      'boundary': 'postal_code'
+    }
+  })
+  t.ok(place instanceof Place)
+  t.equal(place.identity.source, 'osm')
+  t.equal(place.identity.id, 'relation:100')
+  t.equal(place.ontology.class, 'admin')
+  t.equal(place.ontology.type, 'postalcode')
+  t.end()
+})
+tap.test('mapper: normalize "postal_code" boundary - multivalue', (t) => {
+  let place = map({
+    properties: {
+      '@type': 'relation',
+      '@id': '100',
+      'boundary': 'postal_code; administrative'
+    }
+  })
+  t.equal(place.ontology.type, 'postalcode')
+  t.end()
+})
+tap.test('mapper: normalize "postal_code" from the "place" tag too', (t) => {
+  let place = map({
+    properties: {
+      '@type': 'relation',
+      '@id': '100',
+      'place': 'postal_code'
+    }
+  })
+  t.equal(place.ontology.type, 'postalcode')
+  t.end()
+})
+tap.test('mapper: aliasing leaves other boundary types untouched', (t) => {
+  let place = map({
+    properties: {
+      '@type': 'relation',
+      '@id': '100',
+      'boundary': 'administrative'
+    }
+  })
+  t.equal(place.ontology.type, 'administrative')
+  t.end()
+})
 tap.test('mapper: prefer "place" over other tags', (t) => {
   let place = map({
     properties: {


### PR DESCRIPTION
This matches the layer used by WOF. Without this normalization, it's impossible to return both WOF and OSM postalcodes with a single `layers=` param for endpoints that support it.