### PR TITLE
Use shared getDefaultName from pelias/whosonfirst

### DIFF
--- a/import/source/whosonfirst/config/generic.js
+++ b/import/source/whosonfirst/config/generic.js
@@ -1,43 +1,5 @@
 const _ = require('lodash')
 
-/**
- * This file provides some convenience functions for finding the 'generic name'
- * and 'generic abbreviation' of a WOF document.
- *
- * This should probably be a lot easier than it is, and there seems to be some
- * inconsistency within the Pelias codebase about which fields to prefer in
- * certain cases.
- *
- * I've made a best-effort attempt to honour the field mappings which are (at time of writing)
- * being used the pelias/wof-admin-lookup module.
- * The idea is that this repo can be used as a drop-in replacement for wof-admin-lookup.
- *
- * Prior work:
- * [N1] https://github.com/pelias/wof-admin-lookup/blob/e7ea48af6eb5b2b88886dd4b4f71a81e6e38696a/src/pip/components/getDefaultName.js
- * [A1] https://github.com/pelias/wof-admin-lookup/blob/d9abfe32ed40184bd657df463e2faeb6ff2f7326/src/pip/components/extractFields.js#L44-L51
- * [A2] https://github.com/pelias/whosonfirst/blob/fee549816a8a29fc5c3daccc66129677f8d552d6/src/components/extractFields.js#L154
- */
-
-// convenience function to find a generic name for the place
-function getName (properties) {
-  const placeType = _.get(properties, 'wof:placetype')
-  const ISOcountry = _.get(properties, 'iso:country')
-  const quattroAlt = _.get(properties, 'qs:a2_alt')
-  const label = _.get(properties, 'wof:label')
-  const name = _.get(properties, 'wof:name')
-
-  // this US-county specific logic was ported from [A1]
-  if (ISOcountry === 'US' && placeType === 'county' && quattroAlt) {
-    return quattroAlt.trim()
-  }
-
-  // use label
-  if (label) { return label.trim() }
-
-  // use name
-  if (name) { return name.trim() }
-}
-
 // convenience function to find a generic abbreviation for the place
 function getAbbreviation (properties) {
   const placeType = _.get(properties, 'wof:placetype')
@@ -66,6 +28,5 @@ function getAbbreviation (properties) {
 }
 
 module.exports = {
-  name: getName,
   abbreviation: getAbbreviation
 }

--- a/import/source/whosonfirst/map/names.js
+++ b/import/source/whosonfirst/map/names.js
@@ -1,11 +1,12 @@
 const Name = require('../../../../model/Name')
 const language = require('../config/language.json')
 const generic = require('../config/generic')
+const getDefaultName = require('pelias-whosonfirst').getDefaultName
 
 // info about 'abrv': https://github.com/whosonfirst-data/whosonfirst-data/issues/1319
 function mapper (place, properties) {
   // generic name/abbreviation
-  place.addName(new Name('und', 'default', false, generic.name(properties)))
+  place.addName(new Name('und', 'default', false, getDefaultName(properties)))
   place.addName(new Name('und', 'default', true, generic.abbreviation(properties)))
 
   for (let attr in properties) {

--- a/import/source/whosonfirst/map/names.test.js
+++ b/import/source/whosonfirst/map/names.test.js
@@ -58,6 +58,47 @@ tap.test('mapper: wof:name - use qs:a2_alt for USA counties', (t) => {
   t.equal(p.name[0].name, 'example3')
   t.end()
 })
+tap.test('mapper: wof:name - label:eng_x_preferred_longname wins over qs:a2_alt for USA counties', (t) => {
+  let p = new Place()
+  map(p, {
+    'iso:country': 'US',
+    'wof:placetype': 'county',
+    'wof:name': 'Kings',
+    'label:eng_x_preferred_longname': ['Kings County'],
+    'qs:a2_alt': 'a different qs:a2_alt value'
+  })
+
+  t.equal(p.name.length, 1)
+  t.equal(p.name[0].name, 'Kings County')
+  t.end()
+})
+tap.test('mapper: wof:name - longname is used for French counties', (t) => {
+  let p = new Place()
+  map(p, {
+    'iso:country': 'FR',
+    'wof:placetype': 'county',
+    'wof:name': 'Montmarault',
+    'label:eng_x_preferred_longname': ['Montmarault Canton']
+  })
+
+  t.equal(p.name.length, 1)
+  t.equal(p.name[0].name, 'Montmarault Canton')
+  t.end()
+})
+tap.test('mapper: wof:name - longname is NOT used outside the qualifier-preferred allowlist ' +
+  '(eg. Greater London stays Greater London, not the ceremonial-county longname)', (t) => {
+  let p = new Place()
+  map(p, {
+    'iso:country': 'GB',
+    'wof:placetype': 'macrocounty',
+    'wof:name': 'Greater London',
+    'label:eng_x_preferred_longname': ['Greater London Ceremonial County']
+  })
+
+  t.equal(p.name.length, 1)
+  t.equal(p.name[0].name, 'Greater London')
+  t.end()
+})
 
 // generic abbreviation
 tap.test('mapper: wof:abbreviation - prefer wof:shortcode over wof:abbreviation', (t) => {

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "morgan": "^1.9.1",
     "pelias-config": "^6.0.0",
     "pelias-logger": "^1.4.1",
+    "pelias-whosonfirst": "^8.5.0",
     "split2": "^3.1.1",
     "through2": "^3.0.1",
     "turf-point": "^2.0.1",


### PR DESCRIPTION
This is a followup to https://github.com/pelias/whosonfirst/pull/566 which moves us to a common implementation for getting default names from Who's on First records.