### PR TITLE
Catch warning from unsupported hierarchy entries

### DIFF
--- a/import/source/whosonfirst/map/hierarchies.js
+++ b/import/source/whosonfirst/map/hierarchies.js
@@ -18,12 +18,16 @@ function sortHierarchy (hierarchy) {
 
 function mapper (place, properties) {
   const hierarchies = _.get(properties, 'wof:hierarchy', [])
-  const pt = spec.names.get(place.ontology.type)
   const id = parseInt(place.identity.id, 10)
 
   hierarchies.forEach((hierarchy, o) => {
     // sort hierarchy and ensure self-reference exists
-    const sorted = sortHierarchy({ ...hierarchy, ...{ [`${pt.name}_id`]: id } })
+    // note: place.ontology.type is used directly (rather than looking it up
+    // via spec.names) so that records with a placetype not present in the
+    // spec file (eg. a WOF placetype spatial doesn't support yet) still get
+    // a self-reference instead of crashing - sortHierarchy() already treats
+    // unrecognised placetypes as rank 0.
+    const sorted = sortHierarchy({ ...hierarchy, ...{ [`${place.ontology.type}_id`]: id } })
 
     let depth = 0
     for (const key in sorted) {

--- a/import/source/whosonfirst/map/hierarchies.test.js
+++ b/import/source/whosonfirst/map/hierarchies.test.js
@@ -138,6 +138,28 @@ tap.test('mapper: key ordering', (t) => {
 
   t.end()
 })
+tap.test('mapper: record\'s own placetype not in spec (eg. postalregion) should not throw, ' +
+  'and should still get a self-reference', (t) => {
+  const p = new Place(new Identity('wof', '1864205377'), new Ontology('admin', 'postalregion'))
+  map(p, {
+    'wof:hierarchy': [
+      {
+        continent_id: 102191581,
+        country_id: 85633159,
+        empire_id: 136253055
+      }
+    ]
+  })
+
+  t.same([
+    new Hierarchy(p.identity, new Identity('wof', '85633159'), 'wof:0', 0),
+    new Hierarchy(p.identity, new Identity('wof', '136253055'), 'wof:0', 1),
+    new Hierarchy(p.identity, new Identity('wof', '102191581'), 'wof:0', 2),
+    new Hierarchy(p.identity, p.identity, 'wof:0', 3)
+  ], p.hierarchy)
+
+  t.end()
+})
 tap.test('mapper: sort hierarchy - unknown placetype', (t) => {
   const p = new Place(new Identity('wof', '1729339019'), new Ontology('admin', 'locality'))
   map(p, {


### PR DESCRIPTION
During an import I noticed an error like the following:

    error TypeError: Cannot read properties of undefined (reading 'name')
      at /code/import/source/whosonfirst/map/hierarchies.js:26:62
      at Array.forEach (<anonymous>)
      at Object.mapper [as hierarchies] (/code/import/source/whosonfirst/map/hierarchies.js:24:15)
      at mapper (/code/import/source/whosonfirst/map/place.js:39:7)
      at DestroyableTransform._transform (/code/import/mapperStream.js:7:21)
      at Transform._read (/code/node_modules/through2/node_modules/readable-stream/lib/_stream_transform.js:166:10)
      at Transform._write (/code/node_modules/through2/node_modules/readable-stream/lib/_stream_transform.js:155:83)
      at doWrite (/code/node_modules/through2/node_modules/readable-stream/lib/_stream_writable.js:390:139)
      at writeOrBuffer (/code/node_modules/through2/node_modules/readable-stream/lib/_stream_writable.js:381:5)
      at Writable.write (/code/node_modules/through2/node_modules/readable-stream/lib/_stream_writable.js:302:11)

After some investigation these errors don't appar to be hurting anything, they happen when a record in a layer we don't currently support is imported. In this case it was the `postalregion` layer.

We could consider supporting that layer in the future, which I think is also easy, but in the meantime we should at least silence these errors.